### PR TITLE
feat(ui): add per-step model selector with localStorage persistence

### DIFF
--- a/app/ModelSelector.tsx
+++ b/app/ModelSelector.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  getAnalysisModel,
+  getSortModel,
+  saveAnalysisModel,
+  saveSortModel,
+} from "@/lib/model-preferences";
+import type { ModelOption } from "@/app/api/models/route";
+
+interface ModelsPayload {
+  sortModels: ModelOption[];
+  analysisModels: ModelOption[];
+}
+
+export function ModelSelector() {
+  const [open, setOpen] = useState(false);
+  const [models, setModels] = useState<ModelsPayload | null>(null);
+  const [loadError, setLoadError] = useState(false);
+  const [sortModel, setSortModel] = useState("");
+  const [analysisModel, setAnalysisModel] = useState("");
+
+  useEffect(() => {
+    const savedSort = getSortModel();
+    const savedAnalysis = getAnalysisModel();
+
+    fetch("/api/models")
+      .then((r) => r.json())
+      .then((data: ModelsPayload) => {
+        setModels(data);
+
+        // Resolve displayed sort model: saved pref if still in the list, else default.
+        const defaultSort =
+          data.sortModels.find((m) => m.isDefault)?.id ?? data.sortModels[0]?.id ?? "";
+        setSortModel(
+          savedSort && data.sortModels.some((m) => m.id === savedSort)
+            ? savedSort
+            : defaultSort
+        );
+
+        // Same for analysis model.
+        const defaultAnalysis =
+          data.analysisModels.find((m) => m.isDefault)?.id ??
+          data.analysisModels[0]?.id ??
+          "";
+        setAnalysisModel(
+          savedAnalysis && data.analysisModels.some((m) => m.id === savedAnalysis)
+            ? savedAnalysis
+            : defaultAnalysis
+        );
+      })
+      .catch(() => {
+        setLoadError(true);
+        setSortModel(savedSort ?? "");
+        setAnalysisModel(savedAnalysis ?? "");
+      });
+  }, []);
+
+  const handleSortChange = (id: string) => {
+    setSortModel(id);
+    saveSortModel(id);
+  };
+
+  const handleAnalysisChange = (id: string) => {
+    setAnalysisModel(id);
+    saveAnalysisModel(id);
+  };
+
+  const sortDesc = models?.sortModels.find((m) => m.id === sortModel)?.description;
+  const analysisDesc = models?.analysisModels.find((m) => m.id === analysisModel)?.description;
+
+  return (
+    <div className="model-selector-bar">
+      <button
+        type="button"
+        className="model-selector-toggle"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls="model-selector-body"
+      >
+        <span>⚙ Model Settings</span>
+        <span className="chevron" aria-hidden="true">
+          {open ? "▲" : "▼"}
+        </span>
+      </button>
+
+      {open && (
+        <div id="model-selector-body" className="model-selector-body">
+          {loadError && (
+            <p className="note note-error" style={{ margin: "0 0 1rem" }}>
+              Couldn&rsquo;t load the model list — the app will use its defaults.
+            </p>
+          )}
+
+          <div className="field">
+            <label htmlFor="sort-model">Photo Sorting Model</label>
+            {models ? (
+              <select
+                id="sort-model"
+                value={sortModel}
+                onChange={(e) => handleSortChange(e.target.value)}
+                className="model-select"
+              >
+                {models.sortModels.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.displayName}
+                    {m.isDefault ? " (default)" : ""}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <select disabled className="model-select">
+                <option>Loading…</option>
+              </select>
+            )}
+            {sortDesc && <span className="field-hint model-hint">{sortDesc}</span>}
+          </div>
+
+          <div className="field">
+            <label htmlFor="analysis-model">Listing Generation Model</label>
+            {models ? (
+              <select
+                id="analysis-model"
+                value={analysisModel}
+                onChange={(e) => handleAnalysisChange(e.target.value)}
+                className="model-select"
+              >
+                {models.analysisModels.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.displayName}
+                    {m.isDefault ? " (default)" : ""}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <select disabled className="model-select">
+                <option>Loading…</option>
+              </select>
+            )}
+            {analysisDesc && <span className="field-hint model-hint">{analysisDesc}</span>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/ModelSelector.tsx
+++ b/app/ModelSelector.tsx
@@ -30,7 +30,6 @@ export function ModelSelector() {
       .then((data: ModelsPayload) => {
         setModels(data);
 
-        // Resolve displayed sort model: saved pref if still in the list, else default.
         const defaultSort =
           data.sortModels.find((m) => m.isDefault)?.id ?? data.sortModels[0]?.id ?? "";
         setSortModel(
@@ -39,7 +38,6 @@ export function ModelSelector() {
             : defaultSort
         );
 
-        // Same for analysis model.
         const defaultAnalysis =
           data.analysisModels.find((m) => m.isDefault)?.id ??
           data.analysisModels[0]?.id ??
@@ -71,24 +69,22 @@ export function ModelSelector() {
   const analysisDesc = models?.analysisModels.find((m) => m.id === analysisModel)?.description;
 
   return (
-    <div className="model-selector-bar">
+    <>
       <button
         type="button"
-        className="model-selector-toggle"
+        className="btn btn-ghost model-settings-btn"
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
-        aria-controls="model-selector-body"
+        aria-controls="model-settings-body"
       >
-        <span>⚙ Model Settings</span>
-        <span className="chevron" aria-hidden="true">
-          {open ? "▲" : "▼"}
-        </span>
+        ⚙ Model Settings{" "}
+        <span aria-hidden="true">{open ? "▲" : "▼"}</span>
       </button>
 
       {open && (
-        <div id="model-selector-body" className="model-selector-body">
+        <div id="model-settings-body" className="model-settings-body">
           {loadError && (
-            <p className="note note-error" style={{ margin: "0 0 1rem" }}>
+            <p className="note note-error" style={{ margin: 0, gridColumn: "1 / -1" }}>
               Couldn&rsquo;t load the model list — the app will use its defaults.
             </p>
           )}
@@ -142,6 +138,6 @@ export function ModelSelector() {
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -30,14 +30,15 @@ function toImageBlocks(images: AnalyzeRequestBody["images"]): ImageBlock[] {
 async function routeProfile(
   client: Anthropic,
   imageBlocks: ImageBlock[],
-  requested: string
+  requested: string,
+  routerModel: string
 ): Promise<string> {
   const forced = normalizeItemProfile(requested);
   if (forced !== "auto") return forced;
 
   try {
     const resp = await client.messages.create({
-      model: ROUTER_MODEL,
+      model: routerModel,
       max_tokens: 300,
       messages: [
         {
@@ -77,6 +78,15 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  const analysisModel =
+    typeof body.analysisModel === "string" && body.analysisModel.trim()
+      ? body.analysisModel.trim()
+      : ANALYSIS_MODEL;
+  const routerModel =
+    typeof body.routerModel === "string" && body.routerModel.trim()
+      ? body.routerModel.trim()
+      : ROUTER_MODEL;
+
   if (!Array.isArray(body.images) || body.images.length === 0) {
     return NextResponse.json(
       { ok: false, error: "Please add at least one photo." },
@@ -103,7 +113,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const profile = await routeProfile(client, imageBlocks, body.profile);
+    const profile = await routeProfile(client, imageBlocks, body.profile, routerModel);
     const systemPrompt = buildProfiledAnalysisPrompt(profile);
 
     // Retry up to 3 times, mirroring the Python analyze_photos() loop.
@@ -111,7 +121,7 @@ export async function POST(req: NextRequest) {
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
         const resp = await client.messages.create({
-          model: ANALYSIS_MODEL,
+          model: analysisModel,
           max_tokens: 3000,
           // System prompt is large and identical across requests for the same
           // profile — cache it to cut cost and latency.

--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { getClient } from "@/lib/anthropic";
+import type { ModelInfo } from "@anthropic-ai/sdk/resources/models.js";
+
+// Only surface modern Claude families — all of which support vision.
+const VISION_PATTERN = /^claude-(fable|opus|sonnet|haiku)/;
+
+// Haiku is excluded from the listing-generation selector: it materially worsens
+// listing quality compared to every other available model.
+const ANALYSIS_EXCLUDED = /^claude-haiku/;
+
+const DESCRIPTIONS: Record<string, string> = {
+  "claude-fable-5":    "Most capable model — best for rare or complex items. Premium pricing.",
+  "claude-opus-4-8":   "Excellent quality. Recommended for detailed listing generation.",
+  "claude-opus-4-7":   "High quality with strong reasoning. Good all-around choice.",
+  "claude-opus-4-6":   "Solid quality and great value.",
+  "claude-sonnet-4-6": "Fast and capable. Great for sorting; works well for most listings.",
+  "claude-haiku-4-5":  "Fastest and most affordable. Best for photo sorting only.",
+};
+
+const SORT_DEFAULT     = "claude-sonnet-4-6";
+const ANALYSIS_DEFAULT = "claude-opus-4-8";
+
+export interface ModelOption {
+  id: string;
+  displayName: string;
+  description: string;
+  isDefault: boolean;
+}
+
+interface ModelsPayload {
+  sortModels: ModelOption[];
+  analysisModels: ModelOption[];
+}
+
+// Hardcoded fallback when the Anthropic models API call fails.
+const FALLBACK: ModelsPayload = {
+  sortModels: [
+    { id: "claude-opus-4-8",   displayName: "Claude Opus 4.8",   description: DESCRIPTIONS["claude-opus-4-8"],   isDefault: false },
+    { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6", description: DESCRIPTIONS["claude-sonnet-4-6"], isDefault: true  },
+    { id: "claude-haiku-4-5",  displayName: "Claude Haiku 4.5",  description: DESCRIPTIONS["claude-haiku-4-5"],  isDefault: false },
+  ],
+  analysisModels: [
+    { id: "claude-opus-4-8",   displayName: "Claude Opus 4.8",   description: DESCRIPTIONS["claude-opus-4-8"],   isDefault: true  },
+    { id: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6", description: DESCRIPTIONS["claude-sonnet-4-6"], isDefault: false },
+  ],
+};
+
+let cache: ModelsPayload | null = null;
+let cacheAt = 0;
+const CACHE_TTL = 60 * 60 * 1000; // 1 hour
+
+function toOption(m: ModelInfo): ModelOption {
+  return {
+    id: m.id,
+    displayName: m.display_name,
+    description: DESCRIPTIONS[m.id] ?? "Model available from Anthropic.",
+    isDefault: false, // set below
+  };
+}
+
+function buildPayload(raw: ModelInfo[]): ModelsPayload {
+  const vision = raw.filter((m) => VISION_PATTERN.test(m.id));
+  if (vision.length === 0) return FALLBACK;
+
+  const sortModels = vision.map((m) => ({
+    ...toOption(m),
+    isDefault: m.id === SORT_DEFAULT,
+  }));
+  const analysisModels = vision
+    .filter((m) => !ANALYSIS_EXCLUDED.test(m.id))
+    .map((m) => ({ ...toOption(m), isDefault: m.id === ANALYSIS_DEFAULT }));
+
+  // If the default wasn't in the list, mark the first entry as default.
+  if (sortModels.length && !sortModels.some((m) => m.isDefault)) sortModels[0].isDefault = true;
+  if (analysisModels.length && !analysisModels.some((m) => m.isDefault)) analysisModels[0].isDefault = true;
+
+  return { sortModels, analysisModels };
+}
+
+export async function GET() {
+  const now = Date.now();
+  if (cache && now - cacheAt < CACHE_TTL) {
+    return NextResponse.json(cache);
+  }
+
+  try {
+    const client = getClient();
+    const page = await client.models.list();
+    cache = buildPayload(page.data);
+    cacheAt = now;
+    return NextResponse.json(cache);
+  } catch {
+    return NextResponse.json(FALLBACK);
+  }
+}

--- a/app/api/sort/route.ts
+++ b/app/api/sort/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
   const denied = guardApiRequest(req);
   if (denied) return denied;
 
-  let body: { images?: WireImage[] };
+  let body: { images?: WireImage[]; sortModel?: string };
   try {
     body = await req.json();
   } catch {
@@ -24,6 +24,10 @@ export async function POST(req: NextRequest) {
   }
 
   const images = Array.isArray(body.images) ? body.images.slice(0, MAX_PHOTOS) : [];
+  const sortModel =
+    typeof body.sortModel === "string" && body.sortModel.trim()
+      ? body.sortModel.trim()
+      : undefined;
   if (images.length === 0) {
     return NextResponse.json(
       { ok: false, error: "Please add some photos first." },
@@ -42,7 +46,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const result = await sortPhotos(client, images);
+    const result = await sortPhotos(client, images, sortModel);
     if (result.groups.length === 0) {
       return NextResponse.json(
         { ok: false, error: "Couldn't sort these photos. Try fewer at a time." },

--- a/app/globals.css
+++ b/app/globals.css
@@ -941,3 +941,52 @@ textarea {
   color: var(--color-ink-faint);
   font-style: italic;
 }
+
+/* ── Model selector ────────────────────────────────────── */
+.model-selector-bar {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface);
+  padding: 0.7rem 1rem;
+  margin-bottom: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.model-selector-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-ink-faint);
+  gap: 0.5rem;
+  transition: color var(--duration) var(--ease);
+}
+
+.model-selector-toggle:hover {
+  color: var(--color-ink-soft);
+}
+
+.model-selector-body {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.model-select {
+  max-width: 340px;
+}
+
+.model-hint {
+  font-style: italic;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -943,48 +943,36 @@ textarea {
 }
 
 /* ── Model selector ────────────────────────────────────── */
-.model-selector-bar {
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius);
-  background: var(--color-surface);
-  padding: 0.7rem 1rem;
-  margin-bottom: 1.5rem;
-  box-shadow: var(--shadow-sm);
+
+/* The toggle button sits inline with the Sort button in the result-actions
+   flex row. The expanded panel uses order:99 + flex-basis:100% to break
+   onto its own row below both buttons without disrupting the flex layout. */
+.model-settings-btn {
+  align-self: center;
+  white-space: nowrap;
 }
 
-.model-selector-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.78rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--color-ink-faint);
-  gap: 0.5rem;
-  transition: color var(--duration) var(--ease);
-}
-
-.model-selector-toggle:hover {
-  color: var(--color-ink-soft);
-}
-
-.model-selector-body {
+.model-settings-body {
+  flex: 0 0 100%;
+  order: 99;
   display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 1rem;
-  margin-top: 1rem;
-  padding-top: 1rem;
-  border-top: 1px solid var(--color-border);
+  margin-top: 0.25rem;
+  padding: 1rem;
+  background: var(--color-surface-sunk);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+@media (max-width: 560px) {
+  .model-settings-body {
+    grid-template-columns: 1fr;
+  }
 }
 
 .model-select {
-  max-width: 340px;
+  width: 100%;
 }
 
 .model-hint {

--- a/app/globals.css
+++ b/app/globals.css
@@ -968,6 +968,15 @@ textarea {
 @media (max-width: 560px) {
   .model-settings-body {
     grid-template-columns: 1fr;
+    /* Reset order so the panel sits between the toggle and Sort button
+       (DOM order) rather than after the Sort button (order:99 desktop). */
+    order: 0;
+  }
+
+  .result-actions .btn-primary {
+    margin-left: 0;
+    flex: 0 0 100%;
+    justify-content: center;
   }
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -365,7 +365,6 @@ export default function Home() {
       </header>
 
       <EbayConnect />
-      <ModelSelector />
 
       {step === "upload" && (
         <>
@@ -459,6 +458,7 @@ export default function Home() {
             )}
 
             <div className="result-actions" style={{ borderTop: "none", paddingTop: 0 }}>
+              <ModelSelector />
               <button
                 type="button"
                 className="btn btn-primary"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { apiPost } from "@/lib/api-client";
+import { getAnalysisModel, getSortModel } from "@/lib/model-preferences";
 import { resizeImage } from "@/lib/resize";
 import { buildSku } from "@/lib/sku";
 import { EbayConnect } from "./EbayConnect";
+import { ModelSelector } from "./ModelSelector";
 import { ReviewBoard } from "./ReviewBoard";
 import { ListingsView } from "./ListingsView";
 import type {
@@ -143,6 +145,7 @@ export default function Home() {
           mediaType: p.mediaType,
           data: p.previewUrl.split(",")[1],
         })),
+        sortModel: getSortModel() ?? undefined,
       });
       const data = (await readJson(res)) as SortResponse;
       if (!data.ok || !data.groups) {
@@ -243,7 +246,12 @@ export default function Home() {
         )
       );
       try {
-        const res = await apiPost("/api/analyze", { profile: "auto", images: imgs });
+        const res = await apiPost("/api/analyze", {
+          profile: "auto",
+          images: imgs,
+          analysisModel: getAnalysisModel() ?? undefined,
+          routerModel: getSortModel() ?? undefined,
+        });
         const data = (await readJson(res)) as AnalyzeResponse;
         if (!data.ok || !data.listing) {
           throw new Error(data.error || "Could not write this listing.");
@@ -357,6 +365,7 @@ export default function Home() {
       </header>
 
       <EbayConnect />
+      <ModelSelector />
 
       {step === "upload" && (
         <>

--- a/lib/model-preferences.ts
+++ b/lib/model-preferences.ts
@@ -1,0 +1,36 @@
+"use client";
+
+const SORT_KEY     = "listing-writer:sort-model";
+const ANALYSIS_KEY = "listing-writer:analysis-model";
+
+export function getSortModel(): string | null {
+  try {
+    return window.localStorage.getItem(SORT_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function saveSortModel(model: string): void {
+  try {
+    window.localStorage.setItem(SORT_KEY, model);
+  } catch {
+    /* private browsing — pref won't persist */
+  }
+}
+
+export function getAnalysisModel(): string | null {
+  try {
+    return window.localStorage.getItem(ANALYSIS_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function saveAnalysisModel(model: string): void {
+  try {
+    window.localStorage.setItem(ANALYSIS_KEY, model);
+  } catch {
+    /* private browsing — pref won't persist */
+  }
+}

--- a/lib/sortPipeline.ts
+++ b/lib/sortPipeline.ts
@@ -94,7 +94,8 @@ async function claudeJson<T>(
 // batches don't need sequential context — letting us parallelize safely.
 async function groupPhotos(
   client: Anthropic,
-  images: WireImage[]
+  images: WireImage[],
+  model: string
 ): Promise<{ name: string; indices: number[] }[]> {
   const total = images.length;
   const batches: { offset: number; batch: WireImage[]; labelStart: number; labelEnd: number }[] = [];
@@ -115,7 +116,7 @@ async function groupPhotos(
     });
     const data = await claudeJson<{
       groups?: { folder_name?: string; photo_indices?: number[] }[];
-    }>(client, GROUP_MODEL, content, 2000, `group ${b.labelStart}-${b.labelEnd}`);
+    }>(client, model, content, 2000, `group ${b.labelStart}-${b.labelEnd}`);
 
     const out: { name: string; indices: number[] }[] = [];
     for (const g of data?.groups ?? []) {
@@ -136,7 +137,8 @@ async function groupPhotos(
 async function verifyGroups(
   client: Anthropic,
   images: WireImage[],
-  groups: { name: string; indices: number[] }[]
+  groups: { name: string; indices: number[] }[],
+  model: string
 ): Promise<{ groups: { name: string; indices: number[] }[]; orphans: number[] }> {
   const orphans: number[] = [];
 
@@ -146,7 +148,7 @@ async function verifyGroups(
     content.push({ type: "text", text: buildVerifyGroupPrompt(group.indices.length) });
     const result = await claudeJson<{ valid?: boolean; keep_indices?: number[] }>(
       client,
-      CHECK_MODEL,
+      model,
       content,
       300,
       `verify ${group.name}`
@@ -171,7 +173,8 @@ async function verifyGroups(
 async function mergeSplitGroups(
   client: Anthropic,
   images: WireImage[],
-  groups: { name: string; indices: number[] }[]
+  groups: { name: string; indices: number[] }[],
+  model: string
 ): Promise<{ name: string; indices: number[] }[]> {
   if (groups.length < 2) return groups;
 
@@ -191,7 +194,7 @@ async function mergeSplitGroups(
     ];
     const result = await claudeJson<{ merge?: boolean }>(
       client,
-      CHECK_MODEL,
+      model,
       content,
       100,
       `merge ${i}`
@@ -227,11 +230,13 @@ function uniqueNames(groups: { name: string; indices: number[] }[]): SortGroup[]
 
 export async function sortPhotos(
   client: Anthropic,
-  images: WireImage[]
+  images: WireImage[],
+  model?: string
 ): Promise<SortResult> {
-  const grouped = await groupPhotos(client, images);
+  const m = model ?? GROUP_MODEL;
+  const grouped = await groupPhotos(client, images, m);
   if (grouped.length === 0) return { groups: [], orphanIndices: [] };
-  const verified = await verifyGroups(client, images, grouped);
-  const merged = await mergeSplitGroups(client, images, verified.groups);
+  const verified = await verifyGroups(client, images, grouped, m);
+  const merged = await mergeSplitGroups(client, images, verified.groups, m);
   return { groups: uniqueNames(merged), orphanIndices: verified.orphans };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,6 +26,9 @@ export interface AnalyzeRequestBody {
   // Browser-resized JPEG data URLs or raw base64 strings.
   images: { mediaType: string; data: string }[];
   profile: string;
+  // Optional model overrides; server falls back to its defaults when omitted.
+  analysisModel?: string;
+  routerModel?: string;
 }
 
 export interface AnalyzeResponse {


### PR DESCRIPTION
## Summary

The app was previously hard-coded to a single Claude model per step, which caused outages when that model became unavailable (see `199691b`). This PR adds a user-facing model selector so end users can choose which Claude model powers each step of the workflow, with selections persisted across sessions.

### Commits

- **`feat(ui): add model selector for photo sorting and listing generation`** (`2bc3cc1`)
  - `GET /api/models` — server route that fetches available models from the Anthropic API, filters to vision-capable families, and caches the result in memory for 1 hour (no new packages). Haiku 4.5 is excluded from the listing-generation selector because it materially degrades output quality.
  - `lib/model-preferences.ts` — localStorage helpers (`getSortModel` / `saveAnalysisModel` / etc.) following the same pattern as the existing `api-client.ts` access-code storage.
  - `app/ModelSelector.tsx` — client component with two `<select>` dropdowns ("Photo Sorting Model" / "Listing Generation Model"), each showing a user-friendly description. Loads model list on mount, persists selection to localStorage on change, falls back gracefully if the API call fails.
  - `lib/sortPipeline.ts` — `sortPhotos()` now accepts an optional `model?` override threaded through all three internal stages (group, verify, merge). Falls back to the hardcoded `GROUP_MODEL` constant when omitted.
  - `app/api/sort/route.ts` — accepts optional `sortModel` in the request body.
  - `app/api/analyze/route.ts` — accepts optional `analysisModel` and `routerModel` in the request body. `ROUTER_MODEL` follows the user's sort-model preference (same task complexity tier).
  - `lib/types.ts` — adds `analysisModel?` and `routerModel?` fields to `AnalyzeRequestBody`.
  - `app/page.tsx` — embeds `ModelSelector` and passes `getSortModel()` / `getAnalysisModel()` into both API call bodies.

- **`refactor(ui): move model selector inline with Sort button`** (`788f32f`)
  Replaced the full-width top-of-page settings bar with a compact ghost button (`⚙ Model Settings`) that sits to the left of the Sort button inside the upload panel. On expansion, the settings panel breaks onto its own row below both buttons using `order: 99` + `flex-basis: 100%`.

- **`fix(ui): fix mobile layout for model settings + sort button`** (`13c9499`)
  On narrow viewports: resets `model-settings-body` to `order: 0` so the expanded panel appears between the toggle and the Sort button (DOM order, not after it). Sort button is given `flex: 0 0 100%` and `justify-content: center` so it fills its own row with centered text.

## Design decisions

| Decision | Rationale |
|---|---|
| Two selectors (Sort / Listing), not four | `GROUP_MODEL` and `CHECK_MODEL` are the same tier; `ROUTER_MODEL` follows the sort preference. Fewer knobs for non-technical users. |
| Haiku excluded from listing generation | Produces materially weaker listing copy vs. every other available model. |
| `ROUTER_MODEL` follows the sort preference | Routing is lightweight classification — same tier, no separate selector needed. |
| Server-side in-memory cache, no new packages | `let cache` + `let cacheAt` at module level is the idiomatic Next.js approach for a 1-hour TTL. |
| Preferences return `null`, not a hardcoded default | Prevents stale localStorage values from overriding future server-side default changes. |

## Test plan

- [x] `npm run build` passes with no type errors
- [x] "⚙ Model Settings" button appears at the bottom-left of the upload panel, Sort button on the right
- [x] Clicking the toggle shows two dropdowns populated from `/api/models`
- [x] Changing a dropdown saves to `localStorage` (`listing-writer:sort-model` / `listing-writer:analysis-model`)
- [x] Reloading the page restores the saved selection
- [x] Haiku 4.5 does **not** appear in the Listing Generation dropdown
- [x] Haiku 4.5 **does** appear in the Photo Sorting dropdown
- [x] Sort request body includes `sortModel` when a preference is saved
- [x] Analyze request body includes `analysisModel` and `routerModel` when preferences are saved
- [x] On mobile (≤560 px): settings panel expands above the Sort button; Sort button is full-width and centered
- [x] If `/api/models` fails, a soft error note appears and the app continues working with server defaults