### PR TITLE
fix(security): fail closed on NODE_ENV too, not just VERCEL_ENV

### DIFF
--- a/lib/api-guard.ts
+++ b/lib/api-guard.ts
@@ -10,9 +10,9 @@ import crypto from "crypto";
  * (it's remembered in the browser afterwards).
  *
  * If APP_SECRET is unset the guard allows everything in local development,
- * but FAILS CLOSED in production (VERCEL_ENV=production): every guarded
- * route returns 503 until the variable is configured. A forgotten secret
- * must never silently expose money-spending endpoints.
+ * but FAILS CLOSED in production (NODE_ENV=production or VERCEL_ENV=production):
+ * every guarded route returns 503 until the variable is configured. A forgotten
+ * secret must never silently expose money-spending endpoints.
  */
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -70,7 +70,7 @@ export function guardApiRequest(req: NextRequest): NextResponse | null {
   const secret = process.env.APP_SECRET;
   if (!secret) {
     // Fail closed in production — never run a deployed app without an access code.
-    if (process.env.VERCEL_ENV === "production") {
+    if (process.env.NODE_ENV === "production" || process.env.VERCEL_ENV === "production") {
       return NextResponse.json(
         {
           ok: false,


### PR DESCRIPTION
Splits the **`api-guard`** half out of #1 so it can land independently.

## What
`guardApiRequest` previously failed closed only when `VERCEL_ENV=production`. `VERCEL_ENV` is set by Vercel infra, so local/Docker/self-hosted production builds — and Vercel **Preview** deployments — stayed open without `APP_SECRET`. This ORs in `NODE_ENV=production` so every production build fails closed.

```ts
if (process.env.NODE_ENV === "production" || process.env.VERCEL_ENV === "production") {
```

## Verified
Production build (`next build && next start`) with `APP_SECRET` unset → `POST /api/sort` returns `503`. Type-check passes. Only `lib/api-guard.ts` changes (4 lines).

## Not included
The CSP-nonce middleware from #1 is intentionally left out — it blocks scripts on statically prerendered pages (`/`, `/privacy`) and breaks hydration; it needs `force-dynamic` rendering + a retest first (details in #1).

⚠️ After merge, any environment missing `APP_SECRET` (including Preview) will correctly start returning 503 on the AI routes.

Credit: split from @AkinoKitsu's work in #1.
