### PR TITLE
feat: replace Vercel with Docker/Coolify deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.next
+node_modules
+.env*
+*.md
+.vercel

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Copy this file to ".env.local" for local development, and set the same
-# variable in Vercel (Project → Settings → Environment Variables) for production.
+# variables in your deployment environment (Coolify → Environment, or Docker env)
+# for production.
 
 # Your Anthropic API key — get one at https://console.anthropic.com/
 # This stays on the SERVER and is never exposed to the browser.
@@ -23,7 +24,7 @@ EBAY_RU_NAME=
 # Random secret used to encrypt your stored eBay connection. Generate one with:
 #   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 SESSION_SECRET=
-# Your deployed app URL, used for the OAuth redirect (e.g. https://your-app.vercel.app)
+# Your deployed app URL, used for the OAuth redirect (e.g. https://your-app.example.com)
 APP_URL=
 # Optional: your ZIP code. Only used once, to create an eBay inventory location
 # if your account doesn't already have one. Defaults to 10001 if unset.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+FROM node:22-alpine AS base
+
+# ── deps: install production + dev dependencies ──────────────────────────────
+FROM base AS deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# ── builder: compile Next.js ──────────────────────────────────────────────────
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+# Disable Next.js telemetry during build
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN npm run build
+
+# ── runner: minimal production image ─────────────────────────────────────────
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,53 +1,47 @@
 #!/usr/bin/env bash
-# One-shot deploy helper for the Listing Writer app.
+# Build and run the app locally with Docker.
 #
-# First time only:   vercel login        (logs into your Vercel account)
-# Then, any time:    ./deploy.sh         (deploys the current code to your live site)
+# Prerequisites:
+#   1. Install Docker (https://docs.docker.com/get-docker/)
+#   2. Copy .env.example to .env.local and fill in your secrets
+#   3. Run this script: ./deploy.sh
 #
-# It also pushes your ANTHROPIC_API_KEY from .env.local up to Vercel so the
-# live site can write listings. Your key is never committed to git.
+# For Coolify (self-hosted):
+#   - Point Coolify at this repository (GitHub source)
+#   - Set Build Pack to "Dockerfile"
+#   - Add the same environment variables from .env.example in Coolify → Environment
+#   - Set APP_URL to your public domain (e.g. https://listing-writer.example.com)
+#   - Deploy — Coolify builds and runs the Docker image automatically
 
 set -euo pipefail
 cd "$(dirname "$0")"
 
 bold() { printf "\033[1m%s\033[0m\n" "$1"; }
 
-# 1. Make sure you're logged in.
-if ! vercel whoami >/dev/null 2>&1; then
+if ! command -v docker &>/dev/null; then
   echo
-  bold "You're not logged into Vercel yet."
-  echo "Run this once, follow the prompts, then re-run ./deploy.sh:"
+  bold "Docker is not installed."
+  echo "Install it from https://docs.docker.com/get-docker/ and re-run ./deploy.sh"
+  exit 1
+fi
+
+if [ ! -f .env.local ]; then
   echo
-  echo "    vercel login"
+  bold "No .env.local found."
+  echo "Copy .env.example to .env.local and fill in your secrets first:"
+  echo
+  echo "    cp .env.example .env.local"
   echo
   exit 1
 fi
-bold "✓ Logged in to Vercel as $(vercel whoami 2>/dev/null)"
 
-# 2. Link (or create) the Vercel project for this folder, using defaults.
-bold "Linking project (accepting defaults)…"
-vercel link --yes >/dev/null 2>&1 || true
+bold "Building Docker image…"
+docker compose build
 
-# 3. Push the Anthropic key from .env.local into Vercel for every environment.
-if [ -f .env.local ]; then
-  KEY="$(grep -E '^ANTHROPIC_API_KEY=' .env.local | head -1 | cut -d= -f2-)"
-  if [ -n "${KEY:-}" ]; then
-    bold "Uploading ANTHROPIC_API_KEY to Vercel…"
-    for ENVN in production preview development; do
-      vercel env rm ANTHROPIC_API_KEY "$ENVN" -y >/dev/null 2>&1 || true
-      printf "%s" "$KEY" | vercel env add ANTHROPIC_API_KEY "$ENVN" >/dev/null 2>&1 || true
-    done
-    echo "  done."
-  else
-    bold "⚠ No ANTHROPIC_API_KEY found in .env.local — add it in the Vercel dashboard later."
-  fi
-else
-  bold "⚠ No .env.local found — set ANTHROPIC_API_KEY in the Vercel dashboard later."
-fi
-
-# 4. Deploy to production.
-bold "Deploying to production… (first build takes ~1 minute)"
-vercel --prod --yes
+bold "Starting app on http://localhost:3000 …"
+docker compose up -d
 
 echo
-bold "✅ Done! Your live URL is shown above. Bookmark it on your Mac and phone."
+bold "✅ Done! Open http://localhost:3000 in your browser."
+echo "   To view logs: docker compose logs -f"
+echo "   To stop:      docker compose down"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env.local
+    environment:
+      - NODE_ENV=production
+    restart: unless-stopped

--- a/lib/anthropic.ts
+++ b/lib/anthropic.ts
@@ -6,7 +6,7 @@ export function getClient(): Anthropic {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     throw new Error(
-      "ANTHROPIC_API_KEY is not set. Add it in Vercel → Settings → Environment Variables (or in .env.local for local dev)."
+      "ANTHROPIC_API_KEY is not set. Add it to your environment variables (Coolify → Environment, or .env.local for local dev)."
     );
   }
   if (!client) {

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -53,8 +53,8 @@ export async function apiPost(path: string, body: unknown): Promise<Response> {
   for (let attempt = 0; attempt < 2 && res.status === 401; attempt++) {
     const entered = window.prompt(
       attempt === 0
-        ? "Enter your access code. This is the APP_SECRET you set in Vercel (Settings → Environment Variables) — not your Anthropic API key."
-        : "That didn't match the APP_SECRET set in Vercel — try again:"
+        ? "Enter your access code. This is the APP_SECRET you set in your environment variables — not your Anthropic API key."
+        : "That didn't match the APP_SECRET in your environment variables — try again:"
     );
     if (!entered || !entered.trim()) return res; // user cancelled — surface the 401
     code = entered.trim();

--- a/lib/api-guard.ts
+++ b/lib/api-guard.ts
@@ -10,9 +10,9 @@ import crypto from "crypto";
  * (it's remembered in the browser afterwards).
  *
  * If APP_SECRET is unset the guard allows everything in local development,
- * but FAILS CLOSED in production (NODE_ENV=production or VERCEL_ENV=production):
- * every guarded route returns 503 until the variable is configured. A forgotten
- * secret must never silently expose money-spending endpoints.
+ * but FAILS CLOSED in production (NODE_ENV=production): every guarded route
+ * returns 503 until the variable is configured. A forgotten secret must never
+ * silently expose money-spending endpoints.
  */
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -70,12 +70,12 @@ export function guardApiRequest(req: NextRequest): NextResponse | null {
   const secret = process.env.APP_SECRET;
   if (!secret) {
     // Fail closed in production — never run a deployed app without an access code.
-    if (process.env.NODE_ENV === "production" || process.env.VERCEL_ENV === "production") {
+    if (process.env.NODE_ENV === "production") {
       return NextResponse.json(
         {
           ok: false,
           error:
-            "This deployment has no APP_SECRET configured. Set it in Vercel → Settings → Environment Variables, then redeploy.",
+            "This deployment has no APP_SECRET configured. Set it in your environment variables (or Coolify → Environment), then redeploy.",
         },
         { status: 503 }
       );

--- a/lib/ebay/config.ts
+++ b/lib/ebay/config.ts
@@ -1,12 +1,12 @@
 // eBay API constants + credential loading for the web app.
 //
 // Phase 2 uses a SEPARATE eBay keyset from the Python lister (so the two never
-// interfere). These come from environment variables set in Vercel:
+// interfere). These come from environment variables:
 //   EBAY_CLIENT_ID      — the App ID (Client ID)
 //   EBAY_CLIENT_SECRET  — the Cert ID (Client Secret)
 //   EBAY_RU_NAME        — the RuName, whose "auth accepted URL" in the eBay
 //                         developer portal must point at this app's callback
-//                         (e.g. https://your-app.vercel.app/api/ebay/callback)
+//                         (e.g. https://your-app.example.com/api/ebay/callback)
 //   SESSION_SECRET      — random string used to encrypt the stored eBay token
 
 export const EBAY_OAUTH_URL = "https://auth.ebay.com/oauth2/authorize";
@@ -38,7 +38,7 @@ export function getEbayCreds(): EbayCreds {
   const ruName = process.env.EBAY_RU_NAME;
   if (!clientId || !clientSecret || !ruName) {
     throw new Error(
-      "eBay is not configured. Set EBAY_CLIENT_ID, EBAY_CLIENT_SECRET, and EBAY_RU_NAME in Vercel."
+      "eBay is not configured. Set EBAY_CLIENT_ID, EBAY_CLIENT_SECRET, and EBAY_RU_NAME in your environment variables."
     );
   }
   return { clientId, clientSecret, ruName };

--- a/lib/ebay/oauth.ts
+++ b/lib/ebay/oauth.ts
@@ -51,8 +51,8 @@ function tokenErrorMessage(status: number, body: string): string {
       "eBay rejected your app credentials (401 invalid_client). This is the App ID / " +
       "Cert ID pair, not the authorization code you pasted. Check that EBAY_CLIENT_SECRET " +
       "(Cert ID) and EBAY_CLIENT_ID (App ID) come from the same Production keyset — sandbox " +
-      "keys won't work — have no stray spaces or line breaks, and that you redeployed in " +
-      "Vercel after setting them."
+      "keys won't work — have no stray spaces or line breaks, and that you redeployed " +
+      "after setting them."
     );
   }
   if (/invalid_request/i.test(body)) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 // Evaluated once per cold start — env vars do not change at runtime.
-const isProd =
-  process.env.NODE_ENV === "production" ||
-  process.env.VERCEL_ENV === "production";
+const isProd = process.env.NODE_ENV === "production";
 
 export function middleware(request: NextRequest) {
   // Fresh nonce for every HTML response. Buffer is polyfilled by Next.js for

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,8 @@ const projectRoot = dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // Produce a self-contained build for Docker deployment.
+  output: "standalone",
   // Pin the workspace root to this project (a stray lockfile elsewhere on the
   // machine would otherwise confuse Next's root detection).
   outputFileTracingRoot: projectRoot,


### PR DESCRIPTION
- Remove VERCEL_ENV checks; rely solely on NODE_ENV=production
- Update all error messages referencing Vercel settings UI
- Add Dockerfile (Next.js standalone output, multi-stage build)
- Add docker-compose.yml for local Docker testing
- Add .dockerignore to keep image lean
- Enable next.config output:"standalone" required by Dockerfile
- Rewrite deploy.sh for Docker/Coolify workflow


Claude-Session: https://claude.ai/code/session_01HYjeoVWgPbVqcya2cCLTbn