### PR TITLE
fix: return 422 for eBay rejections and log publish failures

### DIFF
--- a/app/api/ebay/publish/route.ts
+++ b/app/api/ebay/publish/route.ts
@@ -43,8 +43,13 @@ export async function POST(req: NextRequest) {
   try {
     const setup = await fetchAccountSetup(accessToken);
     const result = await publishListing(accessToken, setup, body);
-    return NextResponse.json(result, { status: result.success ? 200 : 502 });
+    // A failed publish is a business outcome (eBay rejected the listing), not a
+    // server error. Return 422 so it can't be confused with Vercel's own
+    // platform 502 (function crash/timeout). The client keys off `success`, not
+    // the HTTP status. True server faults still throw and surface as 500 below.
+    return NextResponse.json(result, { status: result.success ? 200 : 422 });
   } catch (e) {
+    console.error(`[ebay/publish] unhandled error sku=${body.sku}:`, e);
     return NextResponse.json(
       { success: false, sku: body.sku, error: (e as Error).message },
       { status: 500 }

--- a/lib/ebay/publish.ts
+++ b/lib/ebay/publish.ts
@@ -430,6 +430,46 @@ function errorIds(r: EbayResp): number[] {
   }
 }
 
+// Extra guidance for eBay errors that a seller can act on directly. Keyed by
+// errorId; appended to the raw eBay message when surfaced in the UI.
+const EBAY_ERROR_HINTS: Record<number, string> = {
+  25019:
+    "eBay rejected the listing's content — usually a restricted or trademarked word in the title/description, or the item is already listed. Edit the title/description and try again.",
+};
+
+// Pull eBay's primary error (id + human message) from a failed response, so we
+// can log it and show it cleanly instead of dumping raw JSON at the user.
+function primaryEbayError(r: EbayResp): { errorId: number; message: string } {
+  const err = r.json?.errors?.[0];
+  if (err) {
+    return {
+      errorId: Number(err.errorId || 0),
+      message: String(err.longMessage || err.message || "").trim(),
+    };
+  }
+  return { errorId: 0, message: (r.text || "").slice(0, 300) };
+}
+
+// One structured log line per publish failure, so Vercel Function Logs actually
+// show what eBay rejected. Without this the whole path logged nothing, which is
+// why failed requests showed "No logs found for this request".
+function logPublishFailure(stage: string, sku: string, r: EbayResp): void {
+  const { errorId, message } = primaryEbayError(r);
+  console.error(
+    `[ebay/publish] ${stage} failed sku=${sku} http=${r.status} errorId=${errorId || "?"} ${message}`
+  );
+}
+
+// User-facing one-liner: eBay's own reason, tagged with its errorId, plus an
+// actionable hint when we have one.
+function publishErrorMessage(stage: string, r: EbayResp): string {
+  const { errorId, message } = primaryEbayError(r);
+  const detail = message || `HTTP ${r.status}`;
+  const head = errorId ? `${stage} (eBay error ${errorId}): ${detail}` : `${stage} (${r.status}): ${detail}`;
+  const hint = errorId ? EBAY_ERROR_HINTS[errorId] : undefined;
+  return hint ? `${head} ${hint}` : head;
+}
+
 function extractExistingOfferId(r: EbayResp): string | null {
   for (const err of r.json?.errors || []) {
     if (err.errorId === 25002) {
@@ -681,7 +721,8 @@ export async function publishListing(
       }
     }
     if (![200, 201, 204].includes(r.status)) {
-      return { success: false, sku, error: `Inventory item failed (${r.status}): ${r.text.slice(0, 300)}` };
+      logPublishFailure("inventory item", sku, r);
+      return { success: false, sku, error: publishErrorMessage("Inventory item failed", r) };
     }
   }
 
@@ -734,7 +775,8 @@ export async function publishListing(
   if (r.status === 400) {
     const existing = extractExistingOfferId(r);
     if (!existing) {
-      return { success: false, sku, error: `Offer creation failed (${r.status}): ${r.text.slice(0, 300)}` };
+      logPublishFailure("offer creation", sku, r);
+      return { success: false, sku, error: publishErrorMessage("Offer creation failed", r) };
     }
     // Update the pre-existing offer instead.
     const upd = await ebayRequest(accessToken, "PUT", `${EBAY_INV_BASE}/offer/${existing}`, {
@@ -742,11 +784,13 @@ export async function publishListing(
       extraHeaders: CL,
     });
     if (![200, 201, 204].includes(upd.status)) {
-      return { success: false, sku, error: `Offer update failed (${upd.status}): ${upd.text.slice(0, 300)}` };
+      logPublishFailure("offer update", sku, upd);
+      return { success: false, sku, error: publishErrorMessage("Offer update failed", upd) };
     }
     offerId = existing;
   } else if (![200, 201].includes(r.status)) {
-    return { success: false, sku, error: `Offer creation failed (${r.status}): ${r.text.slice(0, 300)}` };
+    logPublishFailure("offer creation", sku, r);
+    return { success: false, sku, error: publishErrorMessage("Offer creation failed", r) };
   } else {
     offerId = r.json?.offerId || "";
   }
@@ -833,10 +877,11 @@ async function publishOfferWithRecovery(
     }
   }
 
+  logPublishFailure("publish", sku, r);
   return {
     success: false,
     sku,
     offerId,
-    error: `Publish failed (${r.status}): ${r.text.slice(0, 300)}`,
+    error: publishErrorMessage("Publish failed", r),
   };
 }


### PR DESCRIPTION
## Why

Reported in #17: `POST /api/ebay/publish` shows a **502 in Vercel logs** with **"No logs found for this request"**, so the crash looks silent/unhandled — while the UI shows an eBay `400 / errorId 25019`. Investigation shows this isn't a crash at all:

- **The 502 was by design.** The route returned `status: result.success ? 200 : 502`, so *every* failed publish became a 502 — indistinguishable from Vercel's own platform 502 (function crash/timeout).
- **The path logged nothing.** No `console.error` anywhere in the publish flow, hence "No logs found."
- **UI vs log "divergence" was an illusion.** eBay's real `400 / 25019` was wrapped in the app's 502 body (`r.text.slice(0,300)`); the UI displayed that embedded string. Same event, two layers.
- The underlying failure (25019 "Cannot revise listing… improper words / policy violation") is an eBay **content-policy rejection** of that item, not a code bug.

## Changes

- **Return `422` (not `502`)** for business failures; reserve 5xx for genuine server faults. The client keys off `success`, not HTTP status, so no frontend change is needed.
- **Log one structured line per publish failure** — `sku`, `http`, `errorId`, `message` — so Vercel Function Logs stop showing "No logs found."
- **Surface eBay's `errorId` + message cleanly** instead of dumping raw JSON, with an actionable hint for `25019` (edit title/description and retry).

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Trigger a failing publish and confirm Vercel logs now show `[ebay/publish] … errorId=…` and the response is `422` with a readable `error`
- [ ] Confirm a successful publish still returns `200`