### PR TITLE
feat: drag-to-reorder photos in the review step

### DIFF
--- a/app/ReviewBoard.tsx
+++ b/app/ReviewBoard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import type { ItemGroup, Photo } from "@/lib/types";
 
 interface ReviewBoardProps {
@@ -9,6 +10,7 @@ interface ReviewBoardProps {
   onRename: (groupId: string, name: string) => void;
   onRenameSku: (groupId: string, sku: string) => void;
   onMovePhoto: (photoId: string, toGroupId: string | "orphans") => void;
+  onReorderPhoto: (groupId: string, fromIndex: number, toIndex: number) => void;
   onDeleteGroup: (groupId: string) => void;
   onAddGroup: () => void;
   onWriteAll: () => void;
@@ -44,25 +46,53 @@ function MoveSelect({
   );
 }
 
+interface DragState {
+  draggable?: boolean;
+  isCover?: boolean;
+  dragging?: boolean;
+  dropTarget?: boolean;
+  onDragStart?: (e: React.DragEvent) => void;
+  onDragEnter?: () => void;
+  onDragEnd?: () => void;
+  onDrop?: () => void;
+}
+
 function Thumb({
   photoId,
   groupId,
   groups,
   photoById,
   onMovePhoto,
+  drag,
 }: {
   photoId: string;
   groupId: string | "orphans";
   groups: ItemGroup[];
   photoById: ReviewBoardProps["photoById"];
   onMovePhoto: ReviewBoardProps["onMovePhoto"];
+  drag?: DragState;
 }) {
   const photo = photoById(photoId);
   if (!photo) return null;
+  const cls = ["board-thumb"];
+  if (drag?.draggable) cls.push("draggable");
+  if (drag?.dragging) cls.push("dragging");
+  if (drag?.dropTarget) cls.push("drop-target");
   return (
-    <figure className="board-thumb">
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src={photo.previewUrl} alt="Item photo" />
+    <figure
+      className={cls.join(" ")}
+      draggable={drag?.draggable || undefined}
+      onDragStart={drag?.onDragStart}
+      onDragEnter={drag?.onDragEnter}
+      onDragOver={drag?.draggable ? (e) => e.preventDefault() : undefined}
+      onDrop={drag?.onDrop}
+      onDragEnd={drag?.onDragEnd}
+    >
+      <div className="board-thumb-img">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={photo.previewUrl} alt="Item photo" />
+        {drag?.isCover && <span className="thumb-cover-badge">Cover</span>}
+      </div>
       <MoveSelect
         photoId={photoId}
         currentGroupId={groupId}
@@ -73,6 +103,65 @@ function Thumb({
   );
 }
 
+// A group's ordered photo strip with drag-to-reorder. Order is the eBay photo
+// order (first = cover), so reordering here flows straight through to publish.
+function PhotoGrid({
+  group,
+  groups,
+  photoById,
+  onMovePhoto,
+  onReorderPhoto,
+}: {
+  group: ItemGroup;
+  groups: ItemGroup[];
+  photoById: ReviewBoardProps["photoById"];
+  onMovePhoto: ReviewBoardProps["onMovePhoto"];
+  onReorderPhoto: ReviewBoardProps["onReorderPhoto"];
+}) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+
+  const reset = () => {
+    setDragIndex(null);
+    setOverIndex(null);
+  };
+
+  return (
+    <div className="board-thumbs">
+      {group.photoIds.map((pid, i) => (
+        <Thumb
+          key={pid}
+          photoId={pid}
+          groupId={group.id}
+          groups={groups}
+          photoById={photoById}
+          onMovePhoto={onMovePhoto}
+          drag={{
+            draggable: group.photoIds.length > 1,
+            isCover: i === 0,
+            dragging: dragIndex === i,
+            dropTarget: overIndex === i && dragIndex !== null && dragIndex !== i,
+            onDragStart: (e) => {
+              setDragIndex(i);
+              e.dataTransfer.effectAllowed = "move";
+              // Firefox won't start a drag unless some data is set.
+              e.dataTransfer.setData("text/plain", pid);
+            },
+            onDragEnter: () => setOverIndex(i),
+            onDragEnd: reset,
+            onDrop: () => {
+              if (dragIndex !== null && dragIndex !== i) {
+                onReorderPhoto(group.id, dragIndex, i);
+              }
+              reset();
+            },
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
 export function ReviewBoard({
   groups,
   orphanIds,
@@ -80,6 +169,7 @@ export function ReviewBoard({
   onRename,
   onRenameSku,
   onMovePhoto,
+  onReorderPhoto,
   onDeleteGroup,
   onAddGroup,
   onWriteAll,
@@ -98,8 +188,9 @@ export function ReviewBoard({
         <span className="badge">{totalPhotos} photos sorted</span>
       </div>
       <p style={{ marginTop: 0, color: "var(--color-ink-soft)" }}>
-        Check the groupings below. Rename an item, or use the menu under any
-        photo to move it to the right item. Then write all the listings at once.
+        Check the groupings below. Rename an item, drag photos to reorder them
+        (the first photo is the eBay cover), or use the menu under any photo to
+        move it to another item. Then write all the listings at once.
       </p>
 
       <div className="board">
@@ -135,18 +226,13 @@ export function ReviewBoard({
                 Empty — move photos here using the menu under a photo.
               </p>
             ) : (
-              <div className="board-thumbs">
-                {group.photoIds.map((pid) => (
-                  <Thumb
-                    key={pid}
-                    photoId={pid}
-                    groupId={group.id}
-                    groups={groups}
-                    photoById={photoById}
-                    onMovePhoto={onMovePhoto}
-                  />
-                ))}
-              </div>
+              <PhotoGrid
+                group={group}
+                groups={groups}
+                photoById={photoById}
+                onMovePhoto={onMovePhoto}
+                onReorderPhoto={onReorderPhoto}
+              />
             )}
           </article>
         ))}

--- a/app/globals.css
+++ b/app/globals.css
@@ -771,13 +771,50 @@ textarea {
   gap: 0.3rem;
 }
 
+.board-thumb-img {
+  position: relative;
+}
+
 .board-thumb img {
+  display: block;
   width: 100%;
   aspect-ratio: 1;
   object-fit: cover;
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   background: var(--color-surface-sunk);
+}
+
+.board-thumb.draggable {
+  cursor: grab;
+}
+
+.board-thumb.draggable:active {
+  cursor: grabbing;
+}
+
+.board-thumb.dragging {
+  opacity: 0.4;
+}
+
+.board-thumb.drop-target img {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: 2px;
+}
+
+.thumb-cover-badge {
+  position: absolute;
+  top: 0.25rem;
+  left: 0.25rem;
+  padding: 0.1rem 0.35rem;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #fff;
+  background: var(--color-accent-deep);
+  border-radius: 6px;
+  pointer-events: none;
 }
 
 .move-select {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -209,6 +209,30 @@ export default function Home() {
     });
   };
 
+  // Reorder photos within a group. The array order is the eBay photo order
+  // (index 0 = cover/gallery image), so this is all that's needed — `writeGroup`
+  // and `postGroup` re-derive their image order from `photoIds` at call time.
+  const reorderPhoto = (groupId: string, fromIndex: number, toIndex: number) => {
+    if (fromIndex === toIndex) return;
+    setGroups((prev) =>
+      prev.map((g) => {
+        if (g.id !== groupId) return g;
+        if (
+          fromIndex < 0 ||
+          toIndex < 0 ||
+          fromIndex >= g.photoIds.length ||
+          toIndex >= g.photoIds.length
+        ) {
+          return g;
+        }
+        const next = [...g.photoIds];
+        const [moved] = next.splice(fromIndex, 1);
+        next.splice(toIndex, 0, moved);
+        return { ...g, photoIds: next };
+      })
+    );
+  };
+
   const deleteGroup = (groupId: string) =>
     setGroups((prev) => {
       const target = prev.find((g) => g.id === groupId);
@@ -505,6 +529,7 @@ export default function Home() {
           onRename={rename}
           onRenameSku={renameSku}
           onMovePhoto={movePhoto}
+          onReorderPhoto={reorderPhoto}
           onDeleteGroup={deleteGroup}
           onAddGroup={addGroup}
           onWriteAll={writeAll}


### PR DESCRIPTION
Addresses the **photo-ordering** half of #15 (the eBay-drafts half is out of scope — see the issue thread).

## What

On the review board, each item's photos can now be **dragged to reorder**. The first photo shows a **"Cover"** badge because `photoIds[0]` is what eBay uses as the gallery/primary image.

## Why it's a small change

Photo order was already an ordered `string[]` (`ItemGroup.photoIds`), and both `writeGroup` (listing generation) and `postGroup` (publish) re-derive their image order from that array at call time. So reordering is a pure front-end state update — **no listing-generation or publish/backend changes were needed**. The array order flows straight through to eBay.

## Implementation

- `page.tsx`: `reorderPhoto(groupId, fromIndex, toIndex)` — immutable array splice, same `setGroups` pattern as `movePhoto`.
- `ReviewBoard.tsx`: new `PhotoGrid` component owns per-group drag state; `Thumb` gains optional drag props + a cover badge.
- `globals.css`: grab cursor, drag/drop-target affordances, cover badge.
- Native HTML5 drag-and-drop — **no new dependency**.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `next build` compiles
- [ ] Manual: drag a photo within an item on the review board; confirm order updates and the "Cover" badge tracks position 0
- [ ] Manual: confirm the new order is reflected in the generated listing and the published eBay photo order

## Known limitation

Native HTML5 DnD does not cover touch/mobile reordering. If mobile reordering is wanted, that's a follow-up using a DnD library (e.g. `@dnd-kit`).