### PR TITLE
Fix batch posting, condition grading, bin SKU collisions, photo cap, and item specifics

### DIFF
--- a/app/api/ebay/next-sku/route.ts
+++ b/app/api/ebay/next-sku/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { EBAY_COOKIE, accessTokenFromCookie } from "@/lib/ebay/session";
+import { EBAY_INV_BASE } from "@/lib/ebay/config";
+import { guardApiRequest } from "@/lib/api-guard";
+import { nextIndexFromSkus, sanitizeSku } from "@/lib/sku";
+
+// Where should lettering for a bin continue? Scans the seller's existing
+// inventory SKUs so a second batch from bin K31 starts after the last letter
+// already used (K31-N, K31-O, …) instead of colliding with K31-A.
+
+export const maxDuration = 30;
+
+const PAGE_SIZE = 200;
+const MAX_PAGES = 10; // up to 2000 inventory items scanned
+
+export async function POST(req: NextRequest) {
+  const denied = guardApiRequest(req);
+  if (denied) return denied;
+
+  let prefix = "";
+  try {
+    const body = (await req.json()) as { prefix?: string };
+    prefix = sanitizeSku(String(body.prefix ?? ""));
+  } catch {
+    /* fall through to validation */
+  }
+  if (!prefix) {
+    return NextResponse.json({ ok: false, error: "Missing bin prefix." }, { status: 400 });
+  }
+
+  let accessToken: string | null = null;
+  try {
+    accessToken = await accessTokenFromCookie(req.cookies.get(EBAY_COOKIE)?.value);
+  } catch {
+    /* not connected — treated below */
+  }
+  if (!accessToken) {
+    // Not connected to eBay: no existing SKUs to continue from.
+    return NextResponse.json({ ok: true, nextIndex: 0, connected: false });
+  }
+
+  try {
+    const skus: string[] = [];
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const resp = await fetch(
+        `${EBAY_INV_BASE}/inventory_item?limit=${PAGE_SIZE}&offset=${page * PAGE_SIZE}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: "application/json",
+            "Accept-Language": "en-US",
+          },
+        }
+      );
+      if (!resp.ok) break;
+      const data = await resp.json().catch(() => null);
+      const items: { sku?: string }[] = data?.inventoryItems ?? [];
+      for (const it of items) if (it.sku) skus.push(it.sku);
+      if (items.length < PAGE_SIZE) break;
+    }
+    return NextResponse.json({
+      ok: true,
+      nextIndex: nextIndexFromSkus(skus, prefix),
+      connected: true,
+    });
+  } catch (e) {
+    console.error("[ebay/next-sku]", e);
+    // Non-fatal for the client — worst case it starts at A like before.
+    return NextResponse.json({ ok: true, nextIndex: 0, connected: true });
+  }
+}

--- a/app/api/ebay/publish/route.ts
+++ b/app/api/ebay/publish/route.ts
@@ -5,7 +5,9 @@ import { fetchAccountSetup, publishListing } from "@/lib/ebay/publish";
 import type { PublishInput } from "@/lib/ebay/publish";
 
 // Photo upload + several eBay calls + recovery loops — give it room.
-export const maxDuration = 120;
+// (Uploads now run in parallel, but a 12-photo item with recovery retries can
+// still be slow; 300s is within both Hobby-with-fluid-compute and Pro limits.)
+export const maxDuration = 300;
 
 export async function POST(req: NextRequest) {
   // Check access + rate limit BEFORE parsing the (potentially large) body.

--- a/app/api/merge-check/route.ts
+++ b/app/api/merge-check/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getClient, AnthropicAuthError } from "@/lib/anthropic";
+import { guardApiRequest, safeErrorResponse } from "@/lib/api-guard";
+import { checkMergePair } from "@/lib/sortPipeline";
+import { isAllowedModel } from "@/lib/models";
+import type { WireImage } from "@/lib/images";
+
+// Merge check across sort-chunk boundaries: big batches are sorted 100 photos
+// per request, so an item photographed across a boundary is split into two
+// groups. The client sends the first photo of each candidate pair here.
+
+export const maxDuration = 30;
+
+export async function POST(req: NextRequest) {
+  const denied = guardApiRequest(req);
+  if (denied) return denied;
+
+  let body: { a?: WireImage; b?: WireImage; countA?: number; countB?: number; sortModel?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid request body." }, { status: 400 });
+  }
+  if (!body.a?.data || !body.b?.data) {
+    return NextResponse.json({ ok: false, error: "Missing photos." }, { status: 400 });
+  }
+
+  const requested = typeof body.sortModel === "string" ? body.sortModel.trim() : "";
+  const model = isAllowedModel(requested) ? requested : undefined;
+
+  try {
+    const merge = await checkMergePair(
+      getClient(),
+      body.a,
+      body.b,
+      Math.max(1, Number(body.countA) || 1),
+      Math.max(1, Number(body.countB) || 1),
+      model
+    );
+    return NextResponse.json({ ok: true, merge });
+  } catch (e) {
+    if (e instanceof AnthropicAuthError) {
+      return NextResponse.json({ ok: false, error: e.message }, { status: e.status });
+    }
+    return safeErrorResponse("merge-check", e, "Merge check failed.");
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,10 +18,17 @@ import type {
 } from "@/lib/types";
 
 type Step = "upload" | "review" | "listings";
-// Keep a whole batch's sort payload comfortably under Vercel's 4.5 MB request
-// limit (sort sends small thumbnails for every photo at once).
-const MAX_PHOTOS = 100;
+// Big batches are sorted in chunks of SORT_CHUNK photos per request — each
+// chunk's thumbnail payload stays under Vercel's 4.5 MB body limit — then
+// stitched back together with a merge check at every chunk boundary.
+const MAX_PHOTOS = 300;
+const SORT_CHUNK = 100;
 const WRITE_CONCURRENCY = 3;
+// eBay accepts at most 12 photos per listing; sending more just bloats the
+// publish request toward Vercel's body limit.
+const MAX_PUBLISH_PHOTOS = 12;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 function newId(): string {
   return typeof crypto !== "undefined" && "randomUUID" in crypto
@@ -72,6 +79,10 @@ export default function Home() {
   const [orphanIds, setOrphanIds] = useState<string[]>([]);
   const [dragging, setDragging] = useState(false);
   const [sorting, setSorting] = useState(false);
+  const [sortProgress, setSortProgress] = useState<string | null>(null);
+  // Where bin lettering starts — continues after SKUs already on eBay, so a
+  // second batch from bin K31 gets K31-N… instead of colliding with K31-A.
+  const [skuStart, setSkuStart] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [ebayConnected, setEbayConnected] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -139,44 +150,116 @@ export default function Home() {
     setSorting(true);
     setError(null);
     try {
-      const res = await apiPost("/api/sort", {
-        // Use the small thumbnail for sorting to keep the payload small.
-        images: photos.map((p) => ({
-          mediaType: p.mediaType,
-          data: p.previewUrl.split(",")[1],
-        })),
-        sortModel: getSortModel() ?? undefined,
-      });
-      const data = (await readJson(res)) as SortResponse;
-      if (!data.ok || !data.groups) {
-        throw new Error(data.error || "Could not sort the photos.");
+      // Continue bin lettering after any SKUs already on eBay for this bin.
+      let skuOffset = 0;
+      if (binPrefix.trim()) {
+        try {
+          const r = await apiPost("/api/ebay/next-sku", { prefix: binPrefix.trim() });
+          const d = (await readJson(r)) as { ok?: boolean; nextIndex?: number };
+          if (d.ok && Number.isInteger(d.nextIndex) && (d.nextIndex as number) > 0) {
+            skuOffset = d.nextIndex as number;
+          }
+        } catch {
+          /* not connected or lookup failed — start at A like before */
+        }
       }
-      const idxToId = (i: number) => photos[i]?.id;
+
+      // Sort in chunks so each request's thumbnail payload stays small.
+      type RawGroup = { name: string; photoIds: string[] };
+      const chunkResults: RawGroup[][] = [];
+      const orphanIdsAll: string[] = [];
+      for (let off = 0; off < photos.length; off += SORT_CHUNK) {
+        const chunk = photos.slice(off, off + SORT_CHUNK);
+        if (photos.length > SORT_CHUNK) {
+          setSortProgress(
+            `Sorting photos ${off + 1}–${off + chunk.length} of ${photos.length}…`
+          );
+        }
+        const res = await apiPost("/api/sort", {
+          // Use the small thumbnail for sorting to keep the payload small.
+          images: chunk.map((p) => ({
+            mediaType: p.mediaType,
+            data: p.previewUrl.split(",")[1],
+          })),
+          sortModel: getSortModel() ?? undefined,
+        });
+        const data = (await readJson(res)) as SortResponse;
+        if (!data.ok || !data.groups) {
+          throw new Error(data.error || "Could not sort the photos.");
+        }
+        const idxToId = (i: number) => chunk[i]?.id;
+        chunkResults.push(
+          data.groups
+            .map((g) => ({
+              name: g.name,
+              photoIds: g.photoIndices.map(idxToId).filter(Boolean) as string[],
+            }))
+            .filter((g) => g.photoIds.length > 0)
+        );
+        orphanIdsAll.push(
+          ...((data.orphanIndices ?? []).map(idxToId).filter(Boolean) as string[])
+        );
+      }
+
+      // Stitch chunks back together: an item photographed across a chunk
+      // boundary lands split in two — ask the model whether the group holding
+      // the boundary's last photo and the one holding the next chunk's first
+      // photo are actually the same item.
+      const merged: RawGroup[] = [...(chunkResults[0] ?? [])];
+      for (let c = 1; c < chunkResults.length; c++) {
+        const rest = [...chunkResults[c]];
+        const lastId = photos[c * SORT_CHUNK - 1]?.id;
+        const firstId = photos[c * SORT_CHUNK]?.id;
+        const prevGroup = merged.find((g) => lastId && g.photoIds.includes(lastId));
+        const nextGroup = rest.find((g) => firstId && g.photoIds.includes(firstId));
+        if (prevGroup && nextGroup) {
+          setSortProgress("Checking for items split across batches…");
+          try {
+            const a = photoMap.get(prevGroup.photoIds[0]);
+            const b = photoMap.get(nextGroup.photoIds[0]);
+            if (a && b) {
+              const res = await apiPost("/api/merge-check", {
+                a: { mediaType: a.mediaType, data: a.previewUrl.split(",")[1] },
+                b: { mediaType: b.mediaType, data: b.previewUrl.split(",")[1] },
+                countA: prevGroup.photoIds.length,
+                countB: nextGroup.photoIds.length,
+                sortModel: getSortModel() ?? undefined,
+              });
+              const d = (await readJson(res)) as { ok?: boolean; merge?: boolean };
+              if (d.ok && d.merge) {
+                prevGroup.photoIds = [...prevGroup.photoIds, ...nextGroup.photoIds];
+                rest.splice(rest.indexOf(nextGroup), 1);
+              }
+            }
+          } catch {
+            /* boundary check is best-effort — worst case the item stays split */
+          }
+        }
+        merged.push(...rest);
+      }
+
       const assigned = new Set<string>();
-      const nextGroups: ItemGroup[] = data.groups.map((g, i) => {
-        const ids = g.photoIndices.map(idxToId).filter(Boolean) as string[];
-        ids.forEach((id) => assigned.add(id));
-        return {
-          id: newId(),
-          sku: buildSku(binPrefix, i),
-          name: g.name,
-          photoIds: ids,
-          status: "idle",
-        };
-      });
-      const orphans = (data.orphanIndices ?? [])
-        .map(idxToId)
-        .filter(Boolean) as string[];
-      orphans.forEach((id) => assigned.add(id));
+      merged.forEach((g) => g.photoIds.forEach((id) => assigned.add(id)));
+      orphanIdsAll.forEach((id) => assigned.add(id));
       // Any photo the sorter never placed shouldn't vanish — surface it.
       const leftover = photos.filter((p) => !assigned.has(p.id)).map((p) => p.id);
+
+      const nextGroups: ItemGroup[] = merged.map((g, i) => ({
+        id: newId(),
+        sku: buildSku(binPrefix, skuOffset + i),
+        name: g.name,
+        photoIds: g.photoIds,
+        status: "idle",
+      }));
+      setSkuStart(skuOffset);
       setGroups(nextGroups);
-      setOrphanIds([...orphans, ...leftover]);
+      setOrphanIds([...orphanIdsAll, ...leftover]);
       setStep("review");
     } catch (e) {
       setError((e as Error).message);
     } finally {
       setSorting(false);
+      setSortProgress(null);
     }
   };
 
@@ -247,7 +330,7 @@ export default function Home() {
       ...prev,
       {
         id: newId(),
-        sku: buildSku(binPrefix, prev.length),
+        sku: buildSku(binPrefix, skuStart + prev.length),
         name: `new-item-${prev.length + 1}`,
         photoIds: [],
         status: "idle",
@@ -323,28 +406,50 @@ export default function Home() {
       const images = group.photoIds
         .map((id) => photoMap.get(id))
         .filter((p): p is Photo => Boolean(p))
-        .map((p) => ({ mediaType: p.mediaType, data: p.data }));
+        .map((p) => ({ mediaType: p.mediaType, data: p.data }))
+        .slice(0, MAX_PUBLISH_PHOTOS);
       setGroups((prev) =>
         prev.map((g) =>
           g.id === groupId ? { ...g, postStatus: "posting", postError: undefined } : g
         )
       );
       try {
-        const res = await apiPost("/api/ebay/publish", {
-          sku: group.sku,
-          listing: group.listing,
-          images,
-        });
-        const data = (await readJson(res)) as {
+        let data: {
           success: boolean;
           listingId?: string;
           error?: string;
-        };
-        if (!data.success) throw new Error(data.error || "eBay rejected the listing.");
+          alreadyListed?: boolean;
+        } | null = null;
+        let hadTransientRetry = false;
+        for (let attempt = 0; ; attempt++) {
+          const res = await apiPost("/api/ebay/publish", {
+            sku: group.sku,
+            listing: group.listing,
+            images,
+          });
+          // Wait out rate limits / transient platform errors instead of dying
+          // mid-batch with "try again later".
+          if (
+            attempt < 2 &&
+            (res.status === 429 || res.status === 502 || res.status === 503 || res.status === 504)
+          ) {
+            hadTransientRetry = true;
+            await sleep(res.status === 429 ? 65_000 : 8_000);
+            continue;
+          }
+          data = await readJson(res);
+          break;
+        }
+        // A retried publish that finds the SKU already live means the earlier
+        // attempt actually landed before the timeout — that's a success.
+        if (data && !data.success && data.alreadyListed && hadTransientRetry && data.listingId) {
+          data = { success: true, listingId: data.listingId };
+        }
+        if (!data?.success) throw new Error(data?.error || "eBay rejected the listing.");
         setGroups((prev) =>
           prev.map((g) =>
             g.id === groupId
-              ? { ...g, postStatus: "posted", listingId: data.listingId }
+              ? { ...g, postStatus: "posted", listingId: data!.listingId }
               : g
           )
         );
@@ -425,8 +530,9 @@ export default function Home() {
               />
               <span className="field-hint">
                 Each item gets {binPrefix ? `${binPrefix.trim()}-A, ${binPrefix.trim()}-B` : "A, B, C"}
-                … in order, so you can find it in the bin later. You can edit any
-                SKU after sorting.
+                … in order, so you can find it in the bin later. If this bin
+                already has listings on eBay, lettering continues where it left
+                off. You can edit any SKU after sorting.
               </span>
             </div>
 
@@ -512,8 +618,8 @@ export default function Home() {
               <div className="loading-card">
                 <span className="spinner" aria-hidden="true" />
                 <span>
-                  Grouping photos by item, then double-checking for mixed-up or
-                  split items. This takes a little while for big batches.
+                  {sortProgress ??
+                    "Grouping photos by item, then double-checking for mixed-up or split items. This takes a little while for big batches."}
                 </span>
               </div>
             </section>

--- a/lib/api-guard.ts
+++ b/lib/api-guard.ts
@@ -16,7 +16,10 @@ import crypto from "crypto";
  */
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_MAX_REQUESTS = 10;
+// High enough that a legitimate batch session (sort chunks + parallel listing
+// writes + post-all publishes + status checks) never trips it; APP_SECRET is
+// the real access gate, this only blunts anonymous hammering.
+const RATE_LIMIT_MAX_REQUESTS = 40;
 
 // Per-serverless-instance limiter. Not a global guarantee (each warm lambda
 // has its own map), but it blunts burst abuse at zero infra cost.

--- a/lib/ebay/aspectFill.ts
+++ b/lib/ebay/aspectFill.ts
@@ -1,0 +1,101 @@
+// Model-assisted item-specifics fill.
+//
+// The analysis model writes generic specifics without knowing which aspects the
+// final eBay leaf category actually wants — so live listings still show a pile
+// of "suggested item specifics", which hurts search placement. At publish time
+// we know the exact leaf category and its full aspect list, so one cheap
+// text-only call fills whatever recommended aspects the listing data supports.
+//
+// Strictly best-effort: any failure leaves the aspects untouched.
+
+import { getClient, parseModelJson } from "@/lib/anthropic";
+import type { ListingResult } from "@/lib/types";
+import type { AspectMeta } from "./taxonomy";
+import { clipAspectValue, matchAllowed } from "./aspects";
+
+const FILL_MODEL = "claude-sonnet-4-6";
+const MAX_ASPECTS_TO_FILL = 25;
+const MAX_ALLOWED_VALUES_SHOWN = 40;
+
+function aspectPromptLine(a: AspectMeta): string {
+  if (a.mode === "SELECTION_ONLY" && a.values.length) {
+    const values = a.values.slice(0, MAX_ALLOWED_VALUES_SHOWN).join(" | ");
+    return `- "${a.name}" (must be EXACTLY one of: ${values})`;
+  }
+  const hint = a.values.length
+    ? ` (common values: ${a.values.slice(0, 12).join(" | ")})`
+    : "";
+  return `- "${a.name}" (free text)${hint}`;
+}
+
+export async function fillRecommendedAspects(
+  listing: ListingResult,
+  aspects: Record<string, string[]>,
+  meta: AspectMeta[],
+  sku: string
+): Promise<void> {
+  const have = new Set(Object.keys(aspects).map((k) => k.toLowerCase()));
+  const unfilled = meta
+    .filter((a) => a.name && !have.has(a.name.toLowerCase()))
+    .slice(0, MAX_ASPECTS_TO_FILL);
+  if (unfilled.length === 0) return;
+
+  const itemData = {
+    title: listing.title,
+    brand: listing.brand,
+    item_type: listing.item_type,
+    color: listing.color,
+    size: listing.size,
+    material: listing.material,
+    measurements: listing.measurements,
+    key_features: listing.key_features,
+    item_specifics: listing.item_specifics,
+    description: String(listing.description || "").slice(0, 900),
+  };
+
+  const prompt = `You are completing eBay item specifics for a listing that is about to publish.
+
+ITEM DATA (from photo analysis):
+${JSON.stringify(itemData, null, 1)}
+
+EBAY WANTS VALUES FOR THESE ASPECTS:
+${unfilled.map(aspectPromptLine).join("\n")}
+
+Rules:
+- Fill ONLY aspects you can determine confidently from the item data. Omit everything else — never guess.
+- For "must be EXACTLY one of" aspects, copy the value verbatim from the list.
+- Values must be short (under 65 characters).
+
+Return ONLY valid JSON mapping aspect name to value, e.g. {"Sleeve Length": "Long Sleeve"}. Return {} if nothing can be determined. No markdown, no explanation.`;
+
+  try {
+    const client = getClient();
+    const resp = await client.messages.create({
+      model: FILL_MODEL,
+      max_tokens: 1000,
+      messages: [{ role: "user", content: prompt }],
+    });
+    const block = resp.content.find((b) => b.type === "text");
+    const text = block && block.type === "text" ? block.text : "";
+    const filled = parseModelJson<Record<string, unknown>>(text);
+
+    const byLower = new Map(unfilled.map((a) => [a.name.toLowerCase(), a]));
+    let added = 0;
+    for (const [key, raw] of Object.entries(filled || {})) {
+      const a = byLower.get(String(key).toLowerCase());
+      if (!a || aspects[a.name]) continue;
+      let val = clipAspectValue(String(raw ?? ""));
+      if (!val) continue;
+      if (a.mode === "SELECTION_ONLY") {
+        const canonical = matchAllowed(val, a.values);
+        if (!canonical) continue; // invalid selection — safer to leave empty
+        val = canonical;
+      }
+      aspects[a.name] = [val];
+      added++;
+    }
+    if (added) console.log(`[ebay/publish] aspect-fill added ${added} specifics sku=${sku}`);
+  } catch (e) {
+    console.warn(`[ebay/publish] aspect-fill skipped sku=${sku}: ${(e as Error).message}`);
+  }
+}

--- a/lib/ebay/aspects.ts
+++ b/lib/ebay/aspects.ts
@@ -1,0 +1,58 @@
+// Small helpers for eBay item-specifics (aspects), shared between the publish
+// pipeline and the model-assisted aspect filler.
+
+import type { AspectMeta } from "./taxonomy";
+
+// eBay rejects any item-specific (aspect) value longer than this (error 25002).
+export const MAX_ASPECT_VALUE_LEN = 65;
+
+// Clip an aspect value to eBay's limit, breaking at a word boundary when the
+// truncation point lands far enough in to leave a readable phrase.
+export function clipAspectValue(s: string): string {
+  const t = (s || "").trim();
+  if (t.length <= MAX_ASPECT_VALUE_LEN) return t;
+  const cut = t.slice(0, MAX_ASPECT_VALUE_LEN);
+  const lastSpace = cut.lastIndexOf(" ");
+  return (lastSpace > MAX_ASPECT_VALUE_LEN * 0.6 ? cut.slice(0, lastSpace) : cut).trim();
+}
+
+// Match a value against eBay's allowed list, case-insensitively and tolerating
+// singular/plural (so "Unisex Adult" resolves to the valid "Unisex Adults").
+// Returns the canonical allowed value, or null if there's no match.
+export function matchAllowed(value: string, allowed: string[]): string | null {
+  const ls = (value || "").trim().toLowerCase();
+  if (!ls) return null;
+  for (const v of allowed) {
+    const lv = v.toLowerCase();
+    if (lv === ls || lv === `${ls}s` || `${lv}s` === ls) return v;
+  }
+  return null;
+}
+
+// Rename model-provided aspect keys to eBay's exact (canonical) aspect names,
+// matching case-insensitively. The analysis model says "Country/region of
+// manufacture" or "SLEEVE LENGTH"; eBay only counts the specific if the key
+// matches its localized aspect name exactly — otherwise it stays "suggested"
+// on the live listing.
+export function canonicalizeAspectKeys(
+  aspects: Record<string, string[]>,
+  meta: AspectMeta[]
+): void {
+  const canonical = new Map<string, string>();
+  for (const a of meta) {
+    if (a.name) canonical.set(a.name.toLowerCase(), a.name);
+  }
+  for (const key of Object.keys(aspects)) {
+    const proper = canonical.get(key.toLowerCase());
+    if (proper && proper !== key) {
+      if (!aspects[proper]) aspects[proper] = aspects[key];
+      delete aspects[key];
+    }
+  }
+  // Snap SELECTION_ONLY values to eBay's canonical spelling where we can.
+  for (const a of meta) {
+    if (a.mode !== "SELECTION_ONLY" || !aspects[a.name]?.length) continue;
+    const snapped = matchAllowed(aspects[a.name][0], a.values);
+    if (snapped) aspects[a.name] = [snapped];
+  }
+}

--- a/lib/ebay/publish.ts
+++ b/lib/ebay/publish.ts
@@ -15,6 +15,8 @@ import {
   acceptedConditionIds,
   type AspectMeta,
 } from "./taxonomy";
+import { clipAspectValue, matchAllowed, canonicalizeAspectKeys } from "./aspects";
+import { fillRecommendedAspects } from "./aspectFill";
 import type { ListingResult } from "@/lib/types";
 
 // ── Constants (from the Python script) ───────────────────────────────────────
@@ -219,8 +221,18 @@ function isApparelConditionPolicy(acceptedIds: Set<number>): boolean {
   return acceptedIds.has(2990) || acceptedIds.has(3010);
 }
 
-function conditionIdsForGrade(grade: string, acceptedIds: Set<number>): number[] {
-  const apparel = isApparelConditionPolicy(acceptedIds);
+function conditionIdsForGrade(
+  grade: string,
+  acceptedIds: Set<number>,
+  catKey: string
+): number[] {
+  // When eBay's condition metadata is unavailable, fall back to the category
+  // key so apparel still prefers 2990 (Pre-owned – Excellent). Without this,
+  // a silent metadata failure sent every clothing item as id 3000 — which eBay
+  // displays as "Pre-owned – Good" in fashion categories, whatever the grade.
+  const apparel =
+    isApparelConditionPolicy(acceptedIds) ||
+    (!acceptedIds.size && APPAREL_CATEGORIES.has(catKey));
   const preferences = apparel ? APPAREL_CONDITION_ID_PREFERENCES : GENERAL_CONDITION_ID_PREFERENCES;
   const safeIds = apparel ? APPAREL_SAFE_CONDITION_IDS : GENERAL_SAFE_CONDITION_IDS;
   const preferred = preferences[grade] || preferences.GOOD;
@@ -240,10 +252,14 @@ function conditionIdsForGrade(grade: string, acceptedIds: Set<number>): number[]
 // Ordered eBay Inventory condition enums to try for an internal grade. The grade
 // comes from photo analysis; the allowed IDs come from the chosen leaf category's
 // Metadata policy, so apparel/books/electronics/etc. can each resolve differently.
-function conditionCandidates(grade: string | undefined, acceptedIds: Set<number>): string[] {
+function conditionCandidates(
+  grade: string | undefined,
+  acceptedIds: Set<number>,
+  catKey: string
+): string[] {
   const desired = normalizeConditionInput(grade);
   const out: string[] = [];
-  for (const id of conditionIdsForGrade(desired, acceptedIds)) {
+  for (const id of conditionIdsForGrade(desired, acceptedIds, catKey)) {
     const en = CONDITION_ID_ENUM[id];
     if (en && !out.includes(en)) out.push(en);
   }
@@ -260,19 +276,6 @@ function resolveCategory(listing: ListingResult): {
   const categoryId = explicit || mapped;
   const fallbacks = LEAF_FALLBACKS.filter((c) => c && c !== categoryId);
   return { categoryId, fallbacks };
-}
-
-// eBay rejects any item-specific (aspect) value longer than this (error 25002).
-const MAX_ASPECT_VALUE_LEN = 65;
-
-// Clip an aspect value to eBay's limit, breaking at a word boundary when the
-// truncation point lands far enough in to leave a readable phrase.
-function clipAspectValue(s: string): string {
-  const t = (s || "").trim();
-  if (t.length <= MAX_ASPECT_VALUE_LEN) return t;
-  const cut = t.slice(0, MAX_ASPECT_VALUE_LEN);
-  const lastSpace = cut.lastIndexOf(" ");
-  return (lastSpace > MAX_ASPECT_VALUE_LEN * 0.6 ? cut.slice(0, lastSpace) : cut).trim();
 }
 
 function singleValue(v: unknown): string {
@@ -343,19 +346,6 @@ function buildAspects(listing: ListingResult, catKey: string): Record<string, st
 // The static defaults above can't know what each leaf category requires, nor
 // which values its SELECTION_ONLY aspects accept. We ask eBay for both and make
 // every required aspect valid before publishing — eliminating the 25002 errors.
-
-// Match a value against eBay's allowed list, case-insensitively and tolerating
-// singular/plural (so "Unisex Adult" resolves to the valid "Unisex Adults").
-// Returns the canonical allowed value, or null if there's no match.
-function matchAllowed(value: string, allowed: string[]): string | null {
-  const ls = (value || "").trim().toLowerCase();
-  if (!ls) return null;
-  for (const v of allowed) {
-    const lv = v.toLowerCase();
-    if (lv === ls || lv === `${ls}s` || `${lv}s` === ls) return v;
-  }
-  return null;
-}
 
 // Choose a valid Department from the category's own allowed values, biased by
 // the item's gender cues. Kids categories only allow Boys/Girls/Unisex Kids, so
@@ -566,7 +556,24 @@ function pickFirstPolicy(r: EbayResp, listKey: string, idField: string): string 
   return list.length ? String(list[0][idField] || "") : "";
 }
 
+// Policies and location change rarely; refetching them for every item of a
+// batch adds four eBay calls per publish. Cache per access token for 10 min.
+const setupCache = new Map<string, { setup: AccountSetup; expiresAt: number }>();
+const SETUP_TTL_MS = 10 * 60_000;
+
 export async function fetchAccountSetup(accessToken: string): Promise<AccountSetup> {
+  const cached = setupCache.get(accessToken);
+  if (cached && cached.expiresAt > Date.now()) return cached.setup;
+  const setup = await fetchAccountSetupUncached(accessToken);
+  // Only cache complete setups — a transient miss shouldn't stick for 10 min.
+  if (setup.fulfillmentPolicyId && setup.paymentPolicyId && setup.returnPolicyId) {
+    if (setupCache.size > 50) setupCache.clear();
+    setupCache.set(accessToken, { setup, expiresAt: Date.now() + SETUP_TTL_MS });
+  }
+  return setup;
+}
+
+async function fetchAccountSetupUncached(accessToken: string): Promise<AccountSetup> {
   const mp = `marketplace_id=${EBAY_MARKETPLACE_ID}`;
   const [ful, pay, ret] = await Promise.all([
     ebayRequest(accessToken, "GET", `${EBAY_ACC_BASE}/fulfillment_policy?${mp}`),
@@ -625,9 +632,61 @@ export interface PublishResult {
   listingId?: string;
   offerId?: string;
   error?: string;
+  // The SKU already has a LIVE eBay listing — a duplicate bin batch, not a
+  // transient failure. The client uses this to avoid clobbering the earlier item.
+  alreadyListed?: boolean;
 }
 
 const CL = { "Content-Language": "en-US" };
+
+// A published offer already exists for this SKU (e.g. the same bin code was
+// reused for a second batch). Publishing again would silently overwrite the
+// LIVE listing's photos/title with the new item's — so we refuse instead.
+async function findPublishedOffer(
+  accessToken: string,
+  sku: string
+): Promise<{ offerId: string; listingId: string } | null> {
+  const r = await ebayRequest(
+    accessToken,
+    "GET",
+    `${EBAY_INV_BASE}/offer?sku=${encodeURIComponent(sku)}&marketplace_id=${EBAY_MARKETPLACE_ID}`
+  );
+  if (!r.ok) return null; // 404 = no offers for this SKU — normal
+  for (const o of r.json?.offers ?? []) {
+    if (String(o?.status || "").toUpperCase() === "PUBLISHED") {
+      return {
+        offerId: String(o.offerId || ""),
+        listingId: String(o?.listing?.listingId || ""),
+      };
+    }
+  }
+  return null;
+}
+
+// Upload photos with limited concurrency, preserving order. Sequential uploads
+// were the slowest part of a publish (12 photos ≈ up to a minute on their own)
+// and pushed long batches into Vercel's function timeout.
+async function uploadPhotos(
+  accessToken: string,
+  images: { mediaType: string; data: string }[],
+  sku: string
+): Promise<string[]> {
+  const results: (string | null)[] = new Array(images.length).fill(null);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(4, images.length) }, async () => {
+    while (cursor < images.length) {
+      const i = cursor++;
+      results[i] = await uploadPhoto(
+        accessToken,
+        images[i].data,
+        images[i].mediaType,
+        `${sku}-${i + 1}.jpg`
+      );
+    }
+  });
+  await Promise.all(workers);
+  return results.filter((u): u is string => Boolean(u));
+}
 
 export async function publishListing(
   accessToken: string,
@@ -651,34 +710,60 @@ export async function publishListing(
     };
   }
 
-  // 1. Upload photos → EPS URLs.
-  const photoUrls: string[] = [];
-  for (const img of input.images.slice(0, 12)) {
-    const url = await uploadPhoto(accessToken, img.data, img.mediaType, `${sku}.jpg`);
-    if (url) photoUrls.push(url);
+  // 0. Refuse to clobber a live listing that already uses this SKU (a second
+  // batch from the same bin, or a re-post after a page reload).
+  const existing = await findPublishedOffer(accessToken, sku);
+  if (existing) {
+    return {
+      success: false,
+      sku,
+      alreadyListed: true,
+      offerId: existing.offerId,
+      listingId: existing.listingId,
+      error: `SKU ${sku} already has a live eBay listing. If this is a new item from the same bin, give it the next letter (or re-sort — lettering now continues automatically).`,
+    };
   }
+
+  // 1. Upload photos → EPS URLs (parallel, order preserved).
+  const photoUrls = await uploadPhotos(accessToken, input.images.slice(0, 12), sku);
   if (photoUrls.length === 0) {
     return { success: false, sku, error: "Could not upload any photos to eBay." };
   }
 
   // 2. Inventory item.
   const aspects = buildAspects(listing, catKey);
-  // Ask eBay (in parallel) for the leaf category's REQUIRED specifics and its
-  // accepted condition ids, then make both valid before creating the item.
+  // Ask eBay (in parallel) for the leaf category's specifics and its accepted
+  // condition ids, then make both valid before creating the item.
   // Non-fatal: the recovery loops below remain as a backup if eBay is slow.
   let acceptedConds = new Set<number>();
+  let aspectMeta: AspectMeta[] = [];
   try {
     const [meta, conds] = await Promise.all([
       categoryAspects(catId), // required aspects + valid values  → fixes 25002
-      acceptedConditionIds(catId), // accepted condition ids       → fixes 25021
+      // Seller token: the app token can be rejected by the Metadata API, and a
+      // silent miss here is what mis-graded conditions (see conditionIdsForGrade).
+      acceptedConditionIds(catId, accessToken), // accepted ids   → fixes 25021
     ]);
-    if (meta.length) reconcileAspects(aspects, meta, listing, catKey);
+    aspectMeta = meta;
+    if (meta.length) {
+      canonicalizeAspectKeys(aspects, meta); // model keys → eBay's exact names
+      reconcileAspects(aspects, meta, listing, catKey);
+    }
     acceptedConds = conds;
   } catch {
     /* taxonomy/metadata unavailable — proceed with best-effort values */
   }
-  const condCandidates = conditionCandidates(listing.condition, acceptedConds);
+  // Fill the remaining recommended specifics from the listing data (one cheap
+  // text-only model call) so live listings stop showing "suggested" aspects.
+  if (aspectMeta.length) {
+    await fillRecommendedAspects(listing, aspects, aspectMeta, sku);
+  }
+  const condCandidates = conditionCandidates(listing.condition, acceptedConds, catKey);
   const condition = condCandidates[0] || "USED_EXCELLENT";
+  console.log(
+    `[ebay/publish] sku=${sku} category=${catId} grade=${listing.condition} → condition=${condition}` +
+      (acceptedConds.size ? "" : " (no condition metadata — category-key fallback)")
+  );
   const inventoryItem: any = {
     product: {
       title: String(listing.title || "Untitled").slice(0, 80),
@@ -836,6 +921,18 @@ async function publishOfferWithRecovery(
 
   let r = await doPublish();
   if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "" };
+
+  // The offer already went live (e.g. an earlier attempt timed out after the
+  // publish landed). That's success — recover the listing id and report it.
+  if (/already\s*published/i.test(r.text || "")) {
+    const off = await ebayRequest(accessToken, "GET", `${EBAY_INV_BASE}/offer/${offerId}`);
+    return {
+      success: true,
+      sku,
+      offerId,
+      listingId: String(off.json?.listing?.listingId || ""),
+    };
+  }
 
   let eids = errorIds(r);
 

--- a/lib/ebay/publish.ts
+++ b/lib/ebay/publish.ts
@@ -799,6 +799,11 @@ export async function publishListing(
     ) {
       for (const alt of condCandidates) {
         if (alt === inventoryItem.condition) continue;
+        // Loud on purpose: a silent step-down is how "Excellent" items ended
+        // up displaying as "Pre-owned – Good" with no trace in the logs.
+        console.warn(
+          `[ebay/publish] sku=${sku} condition ${inventoryItem.condition} rejected by category ${catId} — trying ${alt}`
+        );
         inventoryItem.condition = alt;
         r = await putInventory();
         if ([200, 201, 204].includes(r.status)) break;
@@ -951,6 +956,9 @@ async function publishOfferWithRecovery(
   if (eids.includes(25059) || eids.includes(25021)) {
     for (const alt of ctx.condCandidates) {
       if (alt === ctx.inventoryItem.condition) continue;
+      console.warn(
+        `[ebay/publish] sku=${sku} condition ${ctx.inventoryItem.condition} rejected at publish (category ${ctx.catId}) — trying ${alt}`
+      );
       ctx.inventoryItem.condition = alt;
       await putInventory();
       r = await doPublish();

--- a/lib/ebay/session.ts
+++ b/lib/ebay/session.ts
@@ -76,12 +76,25 @@ export function connectionFromToken(refreshToken: string, refreshExpiresIn?: num
   return { refreshToken, refreshExpiresAt: Date.now() + ttl };
 }
 
+// Access tokens live ~2h. Minting one per publish means an extra eBay
+// round-trip on every item of a batch (and risks eBay throttling the refresh
+// grant), so cache them in the warm lambda keyed by refresh token.
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+
 // Mint a short-lived access token from the stored connection cookie value.
 export async function accessTokenFromCookie(
   sealed: string | undefined
 ): Promise<string | null> {
   const conn = await openConnection(sealed);
   if (!conn) return null;
+  const cached = tokenCache.get(conn.refreshToken);
+  if (cached && cached.expiresAt > Date.now()) return cached.token;
   const token = await refreshAccessToken(conn.refreshToken);
+  if (tokenCache.size > 100) tokenCache.clear(); // bound memory
+  tokenCache.set(conn.refreshToken, {
+    token: token.access_token,
+    // Refresh 5 minutes before eBay's stated expiry.
+    expiresAt: Date.now() + Math.max(60, (token.expires_in ?? 7200) - 300) * 1000,
+  });
   return token.access_token;
 }

--- a/lib/ebay/taxonomy.ts
+++ b/lib/ebay/taxonomy.ts
@@ -126,12 +126,21 @@ const condCache = new Map<string, Set<number>>();
 // Lets us pick a condition the category actually allows — fashion leaves reject
 // the classic USED_VERY_GOOD/GOOD/ACCEPTABLE ids (4000/5000/6000), accepting
 // only New variants plus 2990/3000/3010, which is the source of error 25021.
-export async function acceptedConditionIds(categoryId: string): Promise<Set<number>> {
+//
+// Prefer the seller's user token when the caller has one: the client-credentials
+// app token can be rejected by the Metadata API (scope), and a silent failure
+// here is what made every apparel item publish as generic id 3000 — which eBay
+// displays as "Pre-owned – Good" in clothing categories regardless of the item's
+// real grade.
+export async function acceptedConditionIds(
+  categoryId: string,
+  userToken?: string
+): Promise<Set<number>> {
   if (!categoryId) return new Set();
   const cached = condCache.get(categoryId);
   if (cached) return cached;
   try {
-    const token = await appToken();
+    const token = userToken || (await appToken());
     const url =
       `${EBAY_META_BASE}/marketplace/${EBAY_MARKETPLACE_ID}` +
       `/get_item_condition_policies?filter=categoryIds:%7B${encodeURIComponent(categoryId)}%7D`;
@@ -142,7 +151,13 @@ export async function acceptedConditionIds(categoryId: string): Promise<Set<numb
         "Accept-Language": "en-US",
       },
     });
-    if (!resp.ok) return new Set();
+    if (!resp.ok) {
+      // Don't fail silently — this is exactly the path that mis-grades items.
+      console.warn(
+        `[ebay/taxonomy] condition policies unavailable for category ${categoryId} (HTTP ${resp.status})`
+      );
+      return new Set();
+    }
     const data = await resp.json().catch(() => null);
     const ids = new Set<number>();
     for (const p of data?.itemConditionPolicies ?? [])
@@ -152,7 +167,10 @@ export async function acceptedConditionIds(categoryId: string): Promise<Set<numb
       }
     condCache.set(categoryId, ids);
     return ids;
-  } catch {
+  } catch (e) {
+    console.warn(
+      `[ebay/taxonomy] condition policies failed for category ${categoryId}: ${(e as Error).message}`
+    );
     return new Set();
   }
 }

--- a/lib/sku.ts
+++ b/lib/sku.ts
@@ -30,3 +30,30 @@ export function buildSku(prefix: string, index: number): string {
   const suffix = nextSuffix(index);
   return clean ? `${clean}-${suffix}` : suffix;
 }
+
+// Inverse of nextSuffix: "A"→0, "Z"→25, "AA"→26. Returns -1 for non-letters.
+export function suffixToIndex(suffix: string): number {
+  const s = (suffix || "").toUpperCase();
+  if (!/^[A-Z]+$/.test(s)) return -1;
+  let value = 0;
+  for (const ch of s) value = value * 26 + (ch.charCodeAt(0) - 64);
+  return value - 1;
+}
+
+// Given SKUs that already exist on eBay, find where lettering for this bin
+// should continue — so a second batch from bin K31 starts at the letter after
+// the last one used (K31-N…) instead of colliding with K31-A again.
+export function nextIndexFromSkus(existingSkus: string[], prefix: string): number {
+  const clean = sanitizeSku(prefix);
+  if (!clean) return 0;
+  const escaped = clean.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escaped}-([A-Za-z]+)$`, "i");
+  let max = -1;
+  for (const sku of existingSkus) {
+    const m = re.exec(String(sku || "").trim());
+    if (!m) continue;
+    const idx = suffixToIndex(m[1]);
+    if (idx > max) max = idx;
+  }
+  return max + 1;
+}

--- a/lib/sortPipeline.ts
+++ b/lib/sortPipeline.ts
@@ -250,6 +250,39 @@ function uniqueNames(groups: { name: string; indices: number[] }[]): SortGroup[]
   });
 }
 
+// One-off merge check between two groups that landed in DIFFERENT sort chunks
+// (the client sorts big batches 100 photos at a time; an item photographed
+// across the chunk boundary gets split). Same prompt as the in-request merge
+// step, exposed for the /api/merge-check route.
+export async function checkMergePair(
+  client: Anthropic,
+  imageA: WireImage,
+  imageB: WireImage,
+  countA: number,
+  countB: number,
+  model?: string
+): Promise<boolean> {
+  const aBlock = toImageBlock(imageA);
+  const bBlock = toImageBlock(imageB);
+  if (!aBlock || !bBlock) return false;
+  const content: Anthropic.ContentBlockParam[] = [
+    { type: "text", text: "Photo 1:" },
+    aBlock,
+    { type: "text", text: "--- Group B ---" },
+    { type: "text", text: "Photo 2:" },
+    bBlock,
+    { type: "text", text: buildVerifyMergePrompt(countA, countB) },
+  ];
+  const result = await claudeJson<{ merge?: boolean }>(
+    client,
+    model ?? CHECK_MODEL,
+    content,
+    100,
+    "merge chunk-boundary"
+  );
+  return result?.merge === true;
+}
+
 export async function sortPhotos(
   client: Anthropic,
   images: WireImage[],


### PR DESCRIPTION
Full audit of the five reported problems, with fixes for each.

## 1. Stops mid-cycle with "retry later"
- The app's own rate limiter allowed only **10 requests/min across all API routes** — a "Post all" run (plus status checks and listing writes) trips it. Raised to 40/min; `APP_SECRET` remains the real access gate.
- The client now **auto-retries** a publish that hits 429 (waits out the window) or 502/503/504 (transient platform errors) instead of erroring the rest of the batch.
- Each publish is much faster: photos upload **in parallel** (was one-at-a-time), and the eBay access token + business-policy lookups are **cached** across the batch (was ~6 extra eBay calls per item). Publish `maxDuration` raised 120→300s.
- If a retried publish finds the offer already went live (earlier attempt timed out after landing), it's now reported as success instead of an error.

## 2. Everything posted as "Pre-owned – Good"
Root cause: eBay displays condition id **3000 as "Pre-owned – Good"** in clothing categories. The correct id for Excellent apparel is **2990 (Pre-owned – Excellent)**, but the code only picked it when eBay's condition-metadata call succeeded — and that call used a client-credentials app token that the Metadata API can reject, **failing silently** and falling back to 3000 for everything.
- The metadata lookup now uses the **seller's token** (full scopes).
- If metadata is still unavailable, apparel items now fall back to **apparel grading by category key** (2990 first) instead of the generic table.
- Failures are logged, and every publish logs `grade → condition` so mis-grading is visible in Vercel logs.

## 3. Bin SKU collisions on second batches
- New `/api/ebay/next-sku` scans existing inventory SKUs for the bin prefix and **continues lettering where it left off** — a second K31 batch starts at `K31-N` automatically. No "K31-1" needed; items stay findable by bin.
- Safety net: publish now **refuses to overwrite a live listing** that already uses the SKU (previously a duplicate SKU silently replaced the earlier live listing's content).

## 4. Photo cap 100 → 300
The cap existed because all sort thumbnails went in one request (Vercel 4.5 MB body limit). Sorting now runs in **chunks of 100** with progress shown ("Sorting photos 101–200 of 300…"), plus a **model merge-check at each chunk boundary** (new `/api/merge-check`) so an item photographed across the cut isn't split into two listings.

## 5. More item specifics filled on eBay
- Model-provided specifics keys are **canonicalized to eBay's exact aspect names** per leaf category (case/spelling mismatches previously left them "suggested").
- New publish-time **aspect-fill pass** (`lib/ebay/aspectFill.ts`): one cheap text-only Sonnet call fills the remaining recommended aspects from the listing data, validating SELECTION_ONLY values against eBay's allowed list and never guessing.

## Verification
- `next build` passes.
- SKU suffix round-trip + continuation logic verified (`A↔0 … AA↔26`; after `K31-M` comes `K31-N`; case-insensitive; empty inventory starts at A).
- eBay-side behavior (condition id selection, aspect fill) needs a real batch to confirm — publish logs now show exactly what was chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
