### PR TITLE
fix: comply with eBay size standardization — never submit placeholder or invented sizes

### DIFF
--- a/app/ListingCard.tsx
+++ b/app/ListingCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { SIZE_REQUIRED_CATEGORIES } from "@/lib/categories";
 import type { ItemGroup, ListingResult, Photo } from "@/lib/types";
 
 const TITLE_LIMIT = 80;
@@ -78,6 +79,11 @@ export function ListingCard({
   }, [listing?.item_specifics]);
 
   const titleLen = listing?.title?.length ?? 0;
+
+  // eBay's size standardization blocks apparel/footwear listings that are
+  // missing a Size, so flag those for the seller before they post.
+  const sizeRequired = SIZE_REQUIRED_CATEGORIES.has(listing?.category ?? "");
+  const sizeMissing = sizeRequired && !(listing?.size ?? "").trim();
 
   return (
     <article className={`listing-card status-${group.status}`}>
@@ -198,13 +204,30 @@ export function ListingCard({
                 <div className="v">{listing.brand}</div>
               </div>
             )}
-            {listing.size && (
-              <div className="stat">
-                <div className="k">Size</div>
-                <div className="v">{listing.size}</div>
+            {(sizeRequired || listing.size) && (
+              <div className={`stat editable${sizeMissing ? " needs-attention" : ""}`}>
+                <label className="k" htmlFor={`size-${group.id}`}>
+                  Size
+                </label>
+                <input
+                  id={`size-${group.id}`}
+                  type="text"
+                  className="size-input"
+                  value={listing.size ?? ""}
+                  placeholder={sizeRequired ? "e.g. M, 32x34, 10.5" : "—"}
+                  onChange={(e) => onEdit(group.id, { size: e.target.value })}
+                />
               </div>
             )}
           </div>
+
+          {sizeMissing && (
+            <p className="size-warning" role="alert">
+              ⚠️ No size found on the tag. eBay now blocks apparel listings
+              without a standard size — check the photos or measure the item,
+              then fill in Size above before posting.
+            </p>
+          )}
 
           <div className="result-field">
             <label>Description</label>

--- a/app/globals.css
+++ b/app/globals.css
@@ -509,6 +509,29 @@ textarea {
   font-size: 0.92rem;
 }
 
+.stat.editable .size-input {
+  width: 100%;
+  font-size: 1.05rem;
+  font-weight: 600;
+  padding: 0.25rem 0.4rem;
+  background: var(--color-surface);
+}
+
+.stat.needs-attention {
+  border-color: var(--color-danger);
+  background: var(--color-danger-soft);
+}
+
+.size-warning {
+  margin: -0.35rem 0 0;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid var(--color-danger);
+  border-radius: var(--radius-sm);
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  font-size: 0.88rem;
+}
+
 .specifics {
   border: 1px solid var(--color-border);
   border-radius: var(--radius);

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,19 @@
+// Category groupings shared by the publish pipeline (server) and the review
+// UI (client). Keys match the `category` values the analysis prompt returns.
+
+export const APPAREL_CATEGORIES = new Set([
+  "womens_top", "womens_dress", "womens_skirt", "womens_pants", "womens_coat",
+  "womens_sweater", "womens_jeans", "womens_clothing", "womens_shoes", "mens_top",
+  "mens_pants", "mens_coat", "mens_sweater", "mens_jeans", "mens_clothing",
+  "mens_shoes", "scarf", "belt", "hat",
+]);
+
+export const PANTS_CATEGORIES = new Set([
+  "womens_pants", "womens_jeans", "womens_skirt", "mens_pants", "mens_jeans",
+]);
+
+// Categories where eBay's size-standardization enforcement (July 2026) blocks
+// or holds listings with missing or non-standard Size values.
+export const SIZE_REQUIRED_CATEGORIES = new Set(
+  [...APPAREL_CATEGORIES].filter((c) => !["scarf", "belt"].includes(c))
+);

--- a/lib/ebay/publish.ts
+++ b/lib/ebay/publish.ts
@@ -17,6 +17,7 @@ import {
 } from "./taxonomy";
 import { clipAspectValue, matchAllowed, canonicalizeAspectKeys } from "./aspects";
 import { fillRecommendedAspects } from "./aspectFill";
+import { APPAREL_CATEGORIES, PANTS_CATEGORIES } from "@/lib/categories";
 import type { ListingResult } from "@/lib/types";
 
 // ── Constants (from the Python script) ───────────────────────────────────────
@@ -114,25 +115,32 @@ const APPAREL_CONDITION_ID_PREFERENCES: Record<string, number[]> = {
 const GENERAL_SAFE_CONDITION_IDS = [3000, 4000, 5000, 6000, 2750, 1500, 1000, 1750, 7000];
 const APPAREL_SAFE_CONDITION_IDS = [3000, 2990, 3010, 1500, 1000, 1750];
 
-const APPAREL_CATEGORIES = new Set([
-  "womens_top", "womens_dress", "womens_skirt", "womens_pants", "womens_coat",
-  "womens_sweater", "womens_jeans", "womens_clothing", "womens_shoes", "mens_top",
-  "mens_pants", "mens_coat", "mens_sweater", "mens_jeans", "mens_clothing",
-  "mens_shoes", "scarf", "belt", "hat",
-]);
-const PANTS_CATEGORIES = new Set([
-  "womens_pants", "womens_jeans", "womens_skirt", "mens_pants", "mens_jeans",
-]);
-
 const ASPECT_DEFAULTS: Record<string, string> = {
   "Skirt Length": "Knee-Length", "Dress Length": "Knee-Length", Rise: "Mid Rise",
   "Leg Style": "Straight", Closure: "Pull-On", "Shoe Width": "Medium",
   "Heel Height": "Flat", "Toe Shape": "Round", Adjustable: "Yes",
   "Exterior Pockets": "Yes", Lining: "Lined", Hood: "No Hood", "Bag Closure": "Zip",
   "Strap Type": "Adjustable", "Hat Style": "Baseball Cap", "Brim Style": "Curved Bill",
-  "Size Type": "Regular", Size: "Regular", Style: "Casual", Department: "Unisex Adult",
+  "Size Type": "Regular", Style: "Casual", Department: "Unisex Adult",
   Type: "Item", Brand: "Unbranded", Color: "Multicolor", Material: "Mixed Materials",
 };
+
+// eBay's size standardization (enforced July 2026) blocks or holds listings
+// whose Size is a placeholder or non-standard value, so size aspects are only
+// ever filled from real listing data — never from defaults or guesses.
+// "Size Type" (Regular/Plus/Petite/…) is exempt: it's a fit class, not a size.
+function isSizeAspect(name: string): boolean {
+  const n = name.toLowerCase();
+  return n.includes("size") && !n.includes("size type");
+}
+
+const PLACEHOLDER_SIZE_RE =
+  /^(see\s|refer\s|check\s|unknown\b|n\/?a\b|none\b|not\s|no\s(size|tag)|[-?]+$|tbd\b)/i;
+
+function cleanSize(raw: unknown): string {
+  const s = String(raw || "").trim();
+  return PLACEHOLDER_SIZE_RE.test(s) ? "" : s;
+}
 
 // ── eBay REST client (token-authed) ──────────────────────────────────────────
 
@@ -312,7 +320,7 @@ function buildAspects(listing: ListingResult, catKey: string): Record<string, st
   };
 
   put("Brand", String(listing.brand || "").trim());
-  put("Size", String(listing.size || "").trim());
+  put("Size", cleanSize(listing.size));
   put("Color", singleValue(listing.color));
   put("Material", singleValue(listing.material));
   put("Type", String(listing.item_type || "").trim());
@@ -374,7 +382,7 @@ function freeTextDefault(name: string, listing: ListingResult): string {
   const n = name.toLowerCase();
   if (n.includes("brand")) return String(listing.brand || "").trim() || "Unbranded";
   if (n.includes("color")) return singleValue(listing.color) || "Multicolor";
-  if (n.includes("shoe size") || n === "size") return String(listing.size || "").trim();
+  if (n.includes("shoe size") || n === "size") return cleanSize(listing.size);
   if (n.includes("material")) return singleValue(listing.material) || "Man Made";
   if (n.includes("style")) return String(listing.item_specifics?.Style || listing.item_type || "").trim();
   if (n.includes("type")) return String(listing.item_type || "").trim();
@@ -394,16 +402,24 @@ function reconcileAspects(
 
     if (a.mode === "SELECTION_ONLY") {
       // Must be one of eBay's allowed values, or the publish 25002-fails.
+      // Size aspects never fall back to a guessed value — a wrong size
+      // mislabels the item and trips eBay's standardization enforcement.
       const canonical =
         matchAllowed(current || "", a.values) ||
-        matchAllowed(ASPECT_DEFAULTS[a.name] || "", a.values) ||
-        (a.name === "Department" ? pickDepartment(a.values, listing, catKey) : "") ||
-        a.values[0] ||
-        "";
+        (isSizeAspect(a.name)
+          ? ""
+          : matchAllowed(ASPECT_DEFAULTS[a.name] || "", a.values) ||
+            (a.name === "Department" ? pickDepartment(a.values, listing, catKey) : "") ||
+            a.values[0] ||
+            "");
       if (canonical) aspects[a.name] = [canonical];
+      else if (isSizeAspect(a.name)) delete aspects[a.name];
     } else if (!current) {
       // FREE_TEXT and unset — fill from the listing or a sensible default.
-      const v = freeTextDefault(a.name, listing) || ASPECT_DEFAULTS[a.name] || a.values[0] || "";
+      const fromListing = freeTextDefault(a.name, listing);
+      const v =
+        fromListing ||
+        (isSizeAspect(a.name) ? "" : ASPECT_DEFAULTS[a.name] || a.values[0] || "");
       const clipped = clipAspectValue(v);
       if (clipped) aspects[a.name] = [clipped];
     }
@@ -494,6 +510,9 @@ function addMissingAspects(
 ): string[] {
   const added: string[] = [];
   for (const field of missing) {
+    // Never stamp a default into a size aspect — let eBay's "missing item
+    // specific" error surface so the seller supplies the real size.
+    if (isSizeAspect(field)) continue;
     const def = ASPECT_DEFAULTS[field] || "Unbranded";
     aspects[field] = [def];
     added.push(`${field}=${def}`);

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -101,7 +101,7 @@ Return ONLY valid JSON — no markdown, no code fences, no explanation. Use this
   "brand": "Brand name exactly as shown on tag/label. Use 'No Brand' if truly unbranded.",
   "item_type": "Specific descriptive item type",
   "color": ["Primary color", "Secondary color if present — omit if solid"],
-  "size": "Size EXACTLY as printed on the tag. Write 'See photos' if no tag visible.",
+  "size": "Size EXACTLY as printed on the tag. If no size tag is visible but visible measurements clearly indicate one standard size, give that standard size (e.g. 'M', '32x34', '10.5'). Otherwise use an empty string — NEVER write placeholder text like 'See photos', 'Unknown', or 'N/A' (eBay blocks apparel listings with non-standard size values).",
   "material": "Fabric or material composition as shown on tag. Write 'See tag in photos' if unclear.",
   "condition": "One of: NEW_WITH_TAGS, NEW_NO_TAGS, EXCELLENT, VERY_GOOD, GOOD, FAIR",
   "condition_notes": "Honest 2-3 sentence condition description for buyers.",


### PR DESCRIPTION
## Summary

Resolves #20. eBay's [size standardization](https://developer.ebay.com/updates/newsletter/q1_2026) is enforced as of July 2026: apparel/footwear listings with missing, non-standard, or placeholder Size values (eBay's own example: "See description") are blocked or placed on hold. This applies specifically to API-created listings.

The issue reported the `prompts.ts` "See photos" fallback, but the publish pipeline had three more spots that could invent a non-compliant size, so this PR closes all of them:

- **lib/prompts.ts** — size fallback is now: best standard size from visible measurements when clear, otherwise empty string. Placeholder text is explicitly forbidden.
- **lib/ebay/publish.ts** — removed `Size: "Regular"` from `ASPECT_DEFAULTS` ("Regular" is a Size *Type*, not a size). Size aspects are never backfilled from defaults or eBay's first allowed value in `reconcileAspects`/`addMissingAspects` — a wrong guess mislabels the garment. A `cleanSize()` sanitizer also strips placeholder strings ("See photos", "Unknown", "N/A", …) defensively at publish time. "Size Type" keeps its Regular default (it's a fit class, exempt from enforcement).
- **app/ListingCard.tsx** — Size is now an editable field in the review step. Apparel/footwear listings with no size get a visible warning telling the seller to check photos or measure before posting.
- **lib/categories.ts** — new shared module so the client UI and server pipeline use the same apparel category sets.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` passes
- [x] Dev server loads with no console errors
- [ ] Post an apparel item with no visible size tag → review card shows editable Size + warning; publish omits Size rather than sending a placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)