### PR TITLE
Listing-quality overhaul from the full audit: market pricing, vision aspect fill, data hygiene

### DIFF
--- a/app/ListingCard.tsx
+++ b/app/ListingCard.tsx
@@ -85,6 +85,16 @@ export function ListingCard({
   const sizeRequired = SIZE_REQUIRED_CATEGORIES.has(listing?.category ?? "");
   const sizeMissing = sizeRequired && !(listing?.size ?? "").trim();
 
+  // Publishing refuses a missing/zero price (no more invented defaults), so
+  // flag it here the same way size is flagged — before the seller hits Post.
+  const priceNum =
+    typeof listing?.suggested_price === "string"
+      ? parseFloat(listing.suggested_price)
+      : listing?.suggested_price;
+  const priceMissing =
+    group.status === "done" &&
+    (priceNum === undefined || Number.isNaN(priceNum) || priceNum <= 0);
+
   return (
     <article className={`listing-card status-${group.status}`}>
       <header className="listing-card-head" onClick={() => setOpen((o) => !o)}>
@@ -103,9 +113,12 @@ export function ListingCard({
                 <span className="spinner small" aria-hidden="true" /> Writing…
               </>
             )}
-            {group.status === "done" && (
-              <>✅ {formatPrice(listing?.suggested_price)} · ready</>
-            )}
+            {group.status === "done" &&
+              (priceMissing ? (
+                <span style={{ color: "var(--color-danger)" }}>⚠️ needs a price</span>
+              ) : (
+                <>✅ {formatPrice(listing?.suggested_price)} · ready</>
+              ))}
             {group.status === "error" && (
               <span style={{ color: "var(--color-danger)" }}>
                 ⚠️ {group.error || "Failed"}
@@ -153,7 +166,7 @@ export function ListingCard({
           </div>
 
           <div className="meta-row">
-            <div className="stat editable">
+            <div className={`stat editable${priceMissing ? " needs-attention" : ""}`}>
               <label className="k" htmlFor={`price-${group.id}`}>
                 Price
               </label>
@@ -242,6 +255,14 @@ export function ListingCard({
               ⚠️ No size found on the tag. eBay now blocks apparel listings
               without a standard size — check the photos or measure the item,
               then fill in Size above before posting.
+            </p>
+          )}
+
+          {priceMissing && (
+            <p className="size-warning" role="alert">
+              ⚠️ No price yet — the analysis couldn&rsquo;t estimate one for
+              this item. Set a price above before posting
+              {group.comps?.ok ? " (see the market check under Price)" : ""}.
             </p>
           )}
 

--- a/app/ListingCard.tsx
+++ b/app/ListingCard.tsx
@@ -174,6 +174,22 @@ export function ListingCard({
                   }
                 />
               </div>
+              {group.comps?.ok && group.comps.median !== undefined && (
+                <span className="comps-line" title={group.comps.basis}>
+                  Market: {group.comps.count} similar active listings, $
+                  {group.comps.low?.toFixed(0)}–${group.comps.high?.toFixed(0)}
+                  {" · "}
+                  <button
+                    type="button"
+                    className="comps-use"
+                    onClick={() =>
+                      onEdit(group.id, { suggested_price: group.comps!.median })
+                    }
+                  >
+                    use median ${group.comps.median.toFixed(2)}
+                  </button>
+                </span>
+              )}
             </div>
             <div className="stat editable">
               <label className="k" htmlFor={`cond-${group.id}`}>
@@ -257,22 +273,29 @@ export function ListingCard({
 
           {/* eBay posting */}
           {group.postStatus === "posted" ? (
-            <p className="post-result ok">
-              ✅ Posted to eBay
-              {group.listingId ? (
-                <>
-                  {" "}
-                  ·{" "}
-                  <a
-                    href={`https://www.ebay.com/itm/${group.listingId}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    View listing ↗
-                  </a>
-                </>
-              ) : null}
-            </p>
+            <>
+              <p className="post-result ok">
+                ✅ Posted to eBay
+                {group.listingId ? (
+                  <>
+                    {" "}
+                    ·{" "}
+                    <a
+                      href={`https://www.ebay.com/itm/${group.listingId}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      View listing ↗
+                    </a>
+                  </>
+                ) : null}
+              </p>
+              {(group.postWarnings ?? []).map((w) => (
+                <p className="post-result warn" key={w}>
+                  ⚠️ {w}
+                </p>
+              ))}
+            </>
           ) : ebayConnected ? (
             <div className="post-row">
               <button

--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -8,6 +8,7 @@ import {
   normalizeItemProfile,
 } from "@/lib/prompts";
 import { toImageBlock, type ImageBlock } from "@/lib/images";
+import { optimizeTitle } from "@/lib/titleOptimizer";
 import { resolveModel } from "@/lib/models";
 import type { AnalyzeRequestBody, ListingResult } from "@/lib/types";
 
@@ -148,6 +149,9 @@ export async function POST(req: NextRequest) {
         });
         const listing = parseModelJson<ListingResult>(firstText(resp));
         listing.item_profile = profile;
+        // Deterministic title cleanup happens HERE, before the seller reviews —
+        // the title on the card is exactly the title that publishes.
+        listing.title = optimizeTitle(listing);
         return NextResponse.json({ ok: true, listing });
       } catch (err) {
         const fatal = anthropicAuthError(err);

--- a/app/api/ebay/comps/route.ts
+++ b/app/api/ebay/comps/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { guardApiRequest } from "@/lib/api-guard";
+import { isEbayConfigured } from "@/lib/ebay/config";
+import { appToken } from "@/lib/ebay/taxonomy";
+import { searchComps } from "@/lib/ebay/comps";
+import type { ListingResult } from "@/lib/types";
+
+// One Browse-API search; quick.
+export const maxDuration = 30;
+
+// Market price check for a drafted listing: active-comp count, median, and
+// range. Uses the app-level eBay token, so it works before a seller connects.
+export async function POST(req: NextRequest) {
+  const denied = guardApiRequest(req);
+  if (denied) return denied;
+
+  if (!isEbayConfigured()) {
+    return NextResponse.json({ ok: false, error: "eBay isn't configured." }, { status: 200 });
+  }
+
+  let body: { listing?: ListingResult };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid request." }, { status: 400 });
+  }
+  if (!body.listing?.title) {
+    return NextResponse.json({ ok: false, error: "Missing listing." }, { status: 400 });
+  }
+
+  try {
+    const token = await appToken();
+    const comps = await searchComps(token, body.listing);
+    return NextResponse.json({ ok: true, comps });
+  } catch (e) {
+    // Comps are advisory — never let a market-check failure look like an outage.
+    console.warn(`[ebay/comps] lookup failed: ${(e as Error).message}`);
+    return NextResponse.json({ ok: false, error: "Market check unavailable." }, { status: 200 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -993,6 +993,36 @@ textarea {
   color: var(--color-danger);
 }
 
+.post-result.warn {
+  color: var(--color-ink-soft);
+  font-weight: 400;
+  font-size: 0.82rem;
+}
+
+/* Market price check under the Price field */
+.comps-line {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.76rem;
+  font-weight: 400;
+  color: var(--color-ink-soft);
+}
+
+.comps-use {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent-deep);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.comps-use:hover,
+.comps-use:focus-visible {
+  color: var(--color-ink);
+}
+
 .post-hint {
   margin: 0;
   padding-top: 0.75rem;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { ReviewBoard } from "./ReviewBoard";
 import { ListingsView } from "./ListingsView";
 import type {
   AnalyzeResponse,
+  CompsSummary,
   ItemGroup,
   ListingResult,
   Photo,
@@ -370,6 +371,21 @@ export default function Home() {
               : g
           )
         );
+        // Market price check — advisory and best-effort, so it runs in the
+        // background and silently stays hidden if it can't answer.
+        void (async () => {
+          try {
+            const res = await apiPost("/api/ebay/comps", { listing: data.listing });
+            const d = (await readJson(res)) as { ok?: boolean; comps?: CompsSummary };
+            if (d.ok && d.comps?.ok) {
+              setGroups((prev) =>
+                prev.map((g) => (g.id === groupId ? { ...g, comps: d.comps } : g))
+              );
+            }
+          } catch {
+            /* comps unavailable — price stays purely the AI estimate */
+          }
+        })();
       } catch (e) {
         setGroups((prev) =>
           prev.map((g) =>
@@ -419,6 +435,7 @@ export default function Home() {
           listingId?: string;
           error?: string;
           alreadyListed?: boolean;
+          warnings?: string[];
         } | null = null;
         let hadTransientRetry = false;
         for (let attempt = 0; ; attempt++) {
@@ -449,7 +466,12 @@ export default function Home() {
         setGroups((prev) =>
           prev.map((g) =>
             g.id === groupId
-              ? { ...g, postStatus: "posted", listingId: data!.listingId }
+              ? {
+                  ...g,
+                  postStatus: "posted",
+                  listingId: data!.listingId,
+                  postWarnings: data!.warnings,
+                }
               : g
           )
         );

--- a/lib/ebay/aspectFill.ts
+++ b/lib/ebay/aspectFill.ts
@@ -68,17 +68,27 @@ export async function fillRecommendedAspects(
   }
   if (unfilled.length === 0) return;
 
+  // Bound every embedded field — a runaway model output stored in the listing
+  // must not turn this prompt into a token bomb.
+  const clip = (v: unknown, n: number) => String(v ?? "").slice(0, n);
   const itemData = {
-    title: listing.title,
-    brand: listing.brand,
-    item_type: listing.item_type,
-    color: listing.color,
-    size: listing.size,
-    material: listing.material,
-    measurements: listing.measurements,
-    key_features: listing.key_features,
-    item_specifics: listing.item_specifics,
-    description: String(listing.description || "").slice(0, 900),
+    title: clip(listing.title, 120),
+    brand: clip(listing.brand, 80),
+    item_type: clip(listing.item_type, 80),
+    color: (Array.isArray(listing.color) ? listing.color : [listing.color])
+      .filter(Boolean)
+      .slice(0, 4)
+      .map((c) => clip(c, 40)),
+    size: clip(listing.size, 40),
+    material: clip(listing.material, 80),
+    measurements: clip(listing.measurements, 200),
+    key_features: (listing.key_features ?? []).slice(0, 5).map((f) => clip(f, 100)),
+    item_specifics: Object.fromEntries(
+      Object.entries(listing.item_specifics ?? {})
+        .slice(0, 40)
+        .map(([k, v]) => [clip(k, 60), clip(v, 120)])
+    ),
+    description: clip(listing.description, 900),
   };
 
   const imageBlocks = images
@@ -138,7 +148,7 @@ Return ONLY valid JSON mapping aspect name to value (string, or array for multi-
         }
         // Splitting may have broken a compound allowed value apart — rejoin.
         if (!vals.length && parts.length > 1) {
-          for (const sep of [" & ", " / ", ", "]) {
+          for (const sep of [" & ", " / ", ", ", " and "]) {
             const joined = matchAllowed(parts.join(sep), a.values);
             if (joined) {
               vals = [joined];

--- a/lib/ebay/aspectFill.ts
+++ b/lib/ebay/aspectFill.ts
@@ -1,43 +1,71 @@
-// Model-assisted item-specifics fill.
+// Category-aware, photo-grounded item-specifics fill.
 //
-// The analysis model writes generic specifics without knowing which aspects the
-// final eBay leaf category actually wants — so live listings still show a pile
-// of "suggested item specifics", which hurts search placement. At publish time
-// we know the exact leaf category and its full aspect list, so one cheap
-// text-only call fills whatever recommended aspects the listing data supports.
+// The initial analysis model writes generic specifics without knowing which
+// aspects the final eBay leaf category actually wants. At publish time we know
+// the exact leaf category and its full aspect schema — AND we have the original
+// photos in hand (they're uploaded to eBay in the same request). So this pass
+// re-examines the photos against eBay's real aspect names and allowed values,
+// instead of the old text-only call that could never recover anything the
+// first pass missed (model numbers, fabric contents, necklines, hallmarks…).
+//
+// Aspects are prioritized required → recommended → optional, replacing the old
+// arbitrary "first 25 in taxonomy order" cap.
 //
 // Strictly best-effort: any failure leaves the aspects untouched.
 
 import { getClient, parseModelJson } from "@/lib/anthropic";
+import { toImageBlock, type WireImage } from "@/lib/images";
 import type { ListingResult } from "@/lib/types";
 import type { AspectMeta } from "./taxonomy";
-import { clipAspectValue, matchAllowed } from "./aspects";
+import { cleanAspectValue, matchAllowed, splitAspectValues, MAX_MULTI_VALUES } from "./aspects";
 
 const FILL_MODEL = "claude-sonnet-4-6";
-const MAX_ASPECTS_TO_FILL = 25;
+// Prompt-size bound, applied AFTER priority sorting — a category with 60
+// aspects fills its required + recommended ones first, never junk-first.
+const MAX_ASPECTS_TO_FILL = 40;
 const MAX_ALLOWED_VALUES_SHOWN = 40;
+// Vision costs scale with image count; 8 photos cover tags + details for
+// nearly every item while keeping the call cheap (~1–3¢).
+const MAX_FILL_IMAGES = 8;
+
+const USAGE_RANK = { REQUIRED: 0, RECOMMENDED: 1, OPTIONAL: 2 } as const;
+
+export function prioritizeAspects(unfilled: AspectMeta[]): AspectMeta[] {
+  return [...unfilled].sort(
+    (a, b) => (USAGE_RANK[a.usage] ?? 2) - (USAGE_RANK[b.usage] ?? 2)
+  );
+}
 
 function aspectPromptLine(a: AspectMeta): string {
+  const tag = a.usage === "REQUIRED" ? " [required]" : a.usage === "RECOMMENDED" ? " [recommended]" : "";
+  const multi = a.cardinality === "MULTI" ? " (multiple values allowed — return an array)" : "";
   if (a.mode === "SELECTION_ONLY" && a.values.length) {
     const values = a.values.slice(0, MAX_ALLOWED_VALUES_SHOWN).join(" | ");
-    return `- "${a.name}" (must be EXACTLY one of: ${values})`;
+    return `- "${a.name}"${tag}${multi} (must be EXACTLY one of: ${values})`;
   }
   const hint = a.values.length
     ? ` (common values: ${a.values.slice(0, 12).join(" | ")})`
     : "";
-  return `- "${a.name}" (free text)${hint}`;
+  return `- "${a.name}"${tag} (free text)${multi}${hint}`;
 }
 
 export async function fillRecommendedAspects(
   listing: ListingResult,
   aspects: Record<string, string[]>,
   meta: AspectMeta[],
-  sku: string
+  sku: string,
+  images: WireImage[] = []
 ): Promise<void> {
   const have = new Set(Object.keys(aspects).map((k) => k.toLowerCase()));
-  const unfilled = meta
-    .filter((a) => a.name && !have.has(a.name.toLowerCase()))
-    .slice(0, MAX_ASPECTS_TO_FILL);
+  const candidates = prioritizeAspects(
+    meta.filter((a) => a.name && !have.has(a.name.toLowerCase()))
+  );
+  const unfilled = candidates.slice(0, MAX_ASPECTS_TO_FILL);
+  if (candidates.length > unfilled.length) {
+    console.log(
+      `[ebay/publish] aspect-fill sku=${sku}: ${candidates.length - unfilled.length} low-priority aspects skipped (cap ${MAX_ASPECTS_TO_FILL})`
+    );
+  }
   if (unfilled.length === 0) return;
 
   const itemData = {
@@ -53,27 +81,40 @@ export async function fillRecommendedAspects(
     description: String(listing.description || "").slice(0, 900),
   };
 
-  const prompt = `You are completing eBay item specifics for a listing that is about to publish.
+  const imageBlocks = images
+    .slice(0, MAX_FILL_IMAGES)
+    .map(toImageBlock)
+    .filter((b): b is NonNullable<ReturnType<typeof toImageBlock>> => Boolean(b));
 
-ITEM DATA (from photo analysis):
+  const prompt = `You are completing eBay item specifics for a listing that is about to publish.
+${imageBlocks.length ? "The photos above show the actual item. Inspect every photo again — tags, labels, stamps, close-ups — for evidence." : ""}
+ITEM DATA (from earlier photo analysis):
 ${JSON.stringify(itemData, null, 1)}
 
-EBAY WANTS VALUES FOR THESE ASPECTS:
+EBAY WANTS VALUES FOR THESE ASPECTS (exact aspect names for this category):
 ${unfilled.map(aspectPromptLine).join("\n")}
 
 Rules:
-- Fill ONLY aspects you can determine confidently from the item data. Omit everything else — never guess.
+- Fill ONLY aspects supported by visible evidence in the photos or by the item data. Omit everything else — never guess.
+- Use ONLY the supplied eBay aspect names as keys, spelled exactly as given.
 - For "must be EXACTLY one of" aspects, copy the value verbatim from the list.
-- Values must be short (under 65 characters).
+- For "multiple values allowed" aspects you may return a JSON array of values.
+- Never answer with placeholder text like "See photos", "Unknown", or "N/A" — omit the aspect instead.
+- Values must be short (under 65 characters each).
 
-Return ONLY valid JSON mapping aspect name to value, e.g. {"Sleeve Length": "Long Sleeve"}. Return {} if nothing can be determined. No markdown, no explanation.`;
+Return ONLY valid JSON mapping aspect name to value (string, or array for multi-value aspects), e.g. {"Sleeve Length": "Long Sleeve", "Material": ["Cotton", "Polyester"]}. Return {} if nothing can be determined. No markdown, no explanation.`;
 
   try {
     const client = getClient();
     const resp = await client.messages.create({
       model: FILL_MODEL,
-      max_tokens: 1000,
-      messages: [{ role: "user", content: prompt }],
+      max_tokens: 1500,
+      messages: [
+        {
+          role: "user",
+          content: [...imageBlocks, { type: "text", text: prompt }],
+        },
+      ],
     });
     const block = resp.content.find((b) => b.type === "text");
     const text = block && block.type === "text" ? block.text : "";
@@ -84,17 +125,41 @@ Return ONLY valid JSON mapping aspect name to value, e.g. {"Sleeve Length": "Lon
     for (const [key, raw] of Object.entries(filled || {})) {
       const a = byLower.get(String(key).toLowerCase());
       if (!a || aspects[a.name]) continue;
-      let val = clipAspectValue(String(raw ?? ""));
-      if (!val) continue;
+      const parts = Array.isArray(raw)
+        ? raw.map((v) => cleanAspectValue(String(v ?? ""), a.maxLength)).filter(Boolean)
+        : splitAspectValues(raw, a.maxLength);
+      if (!parts.length) continue;
+      let vals: string[];
       if (a.mode === "SELECTION_ONLY") {
-        const canonical = matchAllowed(val, a.values);
-        if (!canonical) continue; // invalid selection — safer to leave empty
-        val = canonical;
+        vals = [];
+        for (const p of parts) {
+          const canonical = matchAllowed(p, a.values);
+          if (canonical && !vals.includes(canonical)) vals.push(canonical);
+        }
+        // Splitting may have broken a compound allowed value apart — rejoin.
+        if (!vals.length && parts.length > 1) {
+          for (const sep of [" & ", " / ", ", "]) {
+            const joined = matchAllowed(parts.join(sep), a.values);
+            if (joined) {
+              vals = [joined];
+              break;
+            }
+          }
+        }
+        if (!vals.length) continue; // invalid selection — safer to leave empty
+      } else {
+        vals = parts;
       }
-      aspects[a.name] = [val];
+      aspects[a.name] =
+        a.cardinality === "MULTI" ? vals.slice(0, MAX_MULTI_VALUES) : vals.slice(0, 1);
       added++;
     }
-    if (added) console.log(`[ebay/publish] aspect-fill added ${added} specifics sku=${sku}`);
+    if (added) {
+      console.log(
+        `[ebay/publish] aspect-fill added ${added} specifics sku=${sku}` +
+          (imageBlocks.length ? ` (vision, ${imageBlocks.length} photos)` : " (text-only)")
+      );
+    }
   } catch (e) {
     console.warn(`[ebay/publish] aspect-fill skipped sku=${sku}: ${(e as Error).message}`);
   }

--- a/lib/ebay/aspects.ts
+++ b/lib/ebay/aspects.ts
@@ -10,8 +10,10 @@ export const MAX_ASPECT_VALUE_LEN = 65;
 // These are not attribute values — "Material = See tag in photos" would become
 // a searchable eBay filter value. They belong in the description, never in an
 // aspect, so every aspect value passes through this check.
+// Deliberately narrow: "see"/"check" only count with a photo/tag-ish object so
+// real values like the brand "See by Chloé" or pattern "Check Print" survive.
 const PLACEHOLDER_VALUE_RE =
-  /^(see\s|refer\s|check\s|unknown\b|unclear\b|n\/?a\b|none\b|not\s(visible|shown|applicable|available|sure)|no\s(size|tag|label|brand\svisible)|unable\s|can'?t\s|tbd\b|maybe\b|possibly\b|[-?.]+$)/i;
+  /^((see|check|refer\sto)\s+.*\b(photo|pic|image|tag|label|listing|description|measurement|above|below)|unknown\b|unclear\b|n\/?a\b|none\b|not\s(visible|shown|applicable|available|sure)|no\s(size|tag|label|brand\svisible)|unable\s|can'?t\s|tbd\b|maybe\b|possibly\b|[-?.]+$)/i;
 
 export function isPlaceholderValue(s: string): boolean {
   const t = (s || "").trim();
@@ -37,13 +39,24 @@ export function cleanAspectValue(s: string, maxLen = MAX_ASPECT_VALUE_LEN): stri
 // Split a model-provided value into its parts ("Cotton / Polyester" →
 // ["Cotton", "Polyester"]), cleaning each. Multi-value aspects keep every
 // part; single-value aspects take the first (see enforceCardinality).
+//
+// A split only happens when EVERY resulting part is a real word (3+ chars):
+// "Black & White" and "Cotton/Polyester" split, while names and sizes whose
+// pieces are fragments — "AC/DC", "H&M", "Texas A&M", "9 1/2", "S/M" — stay
+// whole instead of being shredded.
+const VALUE_SEPARATOR_RE = /\s*(?:\/|,|\||&|\band\b)\s*/i;
+const MIN_SPLIT_PART_LEN = 3;
+
 export function splitAspectValues(v: unknown, maxLen = MAX_ASPECT_VALUE_LEN): string[] {
   const flat: string[] = [];
   const push = (raw: unknown) => {
     const s = String(raw ?? "").trim();
     if (!s) return;
-    // " and " needs surrounding spaces so "Sandals" doesn't split.
-    for (const part of s.split(/\s*(?:\/|,|\||&|\band\b)\s*/i)) {
+    let parts = s.split(VALUE_SEPARATOR_RE).map((p) => p.trim());
+    if (parts.length < 2 || parts.some((p) => p.length < MIN_SPLIT_PART_LEN)) {
+      parts = [s];
+    }
+    for (const part of parts) {
       const cleaned = cleanAspectValue(part.replace(/\s+/g, " "), maxLen);
       if (cleaned && !flat.some((x) => x.toLowerCase() === cleaned.toLowerCase())) {
         flat.push(cleaned);
@@ -62,7 +75,9 @@ export const MAX_MULTI_VALUES = 5;
 
 // Make every aspect's value count legal for eBay. MULTI aspects keep up to
 // MAX_MULTI_VALUES entries; SINGLE aspects (and aspects eBay doesn't know,
-// where MULTI can't be proven safe) collapse to their first value.
+// where MULTI can't be proven safe) collapse to their first value. Features
+// is the long-standing exception: eBay accepts several everywhere it exists,
+// and the app always sent it as a list.
 export function enforceCardinality(
   aspects: Record<string, string[]>,
   meta: AspectMeta[]
@@ -72,8 +87,8 @@ export function enforceCardinality(
     const a = byName.get(key.toLowerCase());
     const vals = aspects[key] || [];
     if (vals.length <= 1) continue;
-    aspects[key] =
-      a?.cardinality === "MULTI" ? vals.slice(0, MAX_MULTI_VALUES) : vals.slice(0, 1);
+    const multi = a ? a.cardinality === "MULTI" : key === "Features";
+    aspects[key] = multi ? vals.slice(0, MAX_MULTI_VALUES) : vals.slice(0, 1);
   }
 }
 

--- a/lib/ebay/aspects.ts
+++ b/lib/ebay/aspects.ts
@@ -6,14 +6,75 @@ import type { AspectMeta } from "./taxonomy";
 // eBay rejects any item-specific (aspect) value longer than this (error 25002).
 export const MAX_ASPECT_VALUE_LEN = 65;
 
+// Buyer-facing phrases the analysis model sometimes writes for unknown fields.
+// These are not attribute values — "Material = See tag in photos" would become
+// a searchable eBay filter value. They belong in the description, never in an
+// aspect, so every aspect value passes through this check.
+const PLACEHOLDER_VALUE_RE =
+  /^(see\s|refer\s|check\s|unknown\b|unclear\b|n\/?a\b|none\b|not\s(visible|shown|applicable|available|sure)|no\s(size|tag|label|brand\svisible)|unable\s|can'?t\s|tbd\b|maybe\b|possibly\b|[-?.]+$)/i;
+
+export function isPlaceholderValue(s: string): boolean {
+  const t = (s || "").trim();
+  return !t || PLACEHOLDER_VALUE_RE.test(t);
+}
+
 // Clip an aspect value to eBay's limit, breaking at a word boundary when the
 // truncation point lands far enough in to leave a readable phrase.
-export function clipAspectValue(s: string): string {
+export function clipAspectValue(s: string, maxLen = MAX_ASPECT_VALUE_LEN): string {
   const t = (s || "").trim();
-  if (t.length <= MAX_ASPECT_VALUE_LEN) return t;
-  const cut = t.slice(0, MAX_ASPECT_VALUE_LEN);
+  if (t.length <= maxLen) return t;
+  const cut = t.slice(0, maxLen);
   const lastSpace = cut.lastIndexOf(" ");
-  return (lastSpace > MAX_ASPECT_VALUE_LEN * 0.6 ? cut.slice(0, lastSpace) : cut).trim();
+  return (lastSpace > maxLen * 0.6 ? cut.slice(0, lastSpace) : cut).trim();
+}
+
+// Clean a single aspect value: placeholder phrases become "", real values get
+// clipped to eBay's length limit.
+export function cleanAspectValue(s: string, maxLen = MAX_ASPECT_VALUE_LEN): string {
+  return isPlaceholderValue(s) ? "" : clipAspectValue(s, maxLen);
+}
+
+// Split a model-provided value into its parts ("Cotton / Polyester" →
+// ["Cotton", "Polyester"]), cleaning each. Multi-value aspects keep every
+// part; single-value aspects take the first (see enforceCardinality).
+export function splitAspectValues(v: unknown, maxLen = MAX_ASPECT_VALUE_LEN): string[] {
+  const flat: string[] = [];
+  const push = (raw: unknown) => {
+    const s = String(raw ?? "").trim();
+    if (!s) return;
+    // " and " needs surrounding spaces so "Sandals" doesn't split.
+    for (const part of s.split(/\s*(?:\/|,|\||&|\band\b)\s*/i)) {
+      const cleaned = cleanAspectValue(part.replace(/\s+/g, " "), maxLen);
+      if (cleaned && !flat.some((x) => x.toLowerCase() === cleaned.toLowerCase())) {
+        flat.push(cleaned);
+      }
+    }
+  };
+  if (Array.isArray(v)) v.forEach(push);
+  else push(v);
+  return flat;
+}
+
+// Cap how many values a MULTI aspect carries — enough to keep real data
+// ("Casual, Travel, Workwear") without letting a rambling model response
+// turn one aspect into a paragraph.
+export const MAX_MULTI_VALUES = 5;
+
+// Make every aspect's value count legal for eBay. MULTI aspects keep up to
+// MAX_MULTI_VALUES entries; SINGLE aspects (and aspects eBay doesn't know,
+// where MULTI can't be proven safe) collapse to their first value.
+export function enforceCardinality(
+  aspects: Record<string, string[]>,
+  meta: AspectMeta[]
+): void {
+  const byName = new Map(meta.map((a) => [a.name.toLowerCase(), a]));
+  for (const key of Object.keys(aspects)) {
+    const a = byName.get(key.toLowerCase());
+    const vals = aspects[key] || [];
+    if (vals.length <= 1) continue;
+    aspects[key] =
+      a?.cardinality === "MULTI" ? vals.slice(0, MAX_MULTI_VALUES) : vals.slice(0, 1);
+  }
 }
 
 // Match a value against eBay's allowed list, case-insensitively and tolerating
@@ -52,7 +113,26 @@ export function canonicalizeAspectKeys(
   // Snap SELECTION_ONLY values to eBay's canonical spelling where we can.
   for (const a of meta) {
     if (a.mode !== "SELECTION_ONLY" || !aspects[a.name]?.length) continue;
-    const snapped = matchAllowed(aspects[a.name][0], a.values);
-    if (snapped) aspects[a.name] = [snapped];
+    const vals = aspects[a.name];
+    const matched: string[] = [];
+    for (const v of vals) {
+      const m = matchAllowed(v, a.values);
+      if (m && !matched.includes(m)) matched.push(m);
+    }
+    if (matched.length) {
+      aspects[a.name] = matched;
+      continue;
+    }
+    // The value may be a compound allowed value that value-splitting broke
+    // apart ("Hook & Eye" → Hook, Eye) — try rejoining before giving up.
+    if (vals.length > 1) {
+      for (const sep of [" & ", " / ", ", ", " and "]) {
+        const joined = matchAllowed(vals.join(sep), a.values);
+        if (joined) {
+          aspects[a.name] = [joined];
+          break;
+        }
+      }
+    }
   }
 }

--- a/lib/ebay/comps.ts
+++ b/lib/ebay/comps.ts
@@ -16,9 +16,10 @@ const EBAY_BROWSE_SEARCH = "https://api.ebay.com/buy/browse/v1/item_summary/sear
 export type { CompsSummary };
 
 // Comps that poison the statistics: multi-item lots when ours is one item,
-// parts/repair listings, reproductions, and empty-box scams.
+// parts/repair listings, reproductions, and empty-box scams. (No "x 12"-style
+// quantity heuristic — it false-positived on dimension titles like "16 x 20".)
 const BAD_COMP_TITLE_RE =
-  /\b(lot(?:\sof)?|bundle|wholesale|reseller|bulk|x\s?\d{2,}|for\sparts|parts\sonly|repair|broken|damaged|repro(?:duction)?|replica|fake|style\sof|box\sonly|case\sonly|manual\sonly)\b/i;
+  /\b(lot(?:\sof)?|bundle|wholesale|reseller|bulk|for\sparts|parts\sonly|repair|broken|damaged|repro(?:duction)?|replica|fake|style\sof|box\sonly|case\sonly|manual\sonly)\b/i;
 
 const NEW_CONDITION_IDS = new Set([1000, 1500, 1750]);
 
@@ -106,6 +107,12 @@ export function compStats(prices: number[]): Omit<CompsSummary, "ok" | "query" |
   };
 }
 
+// Identical items in a batch (or a re-analyze) shouldn't re-spend Browse API
+// quota — cache per warm lambda for a while.
+const compsCache = new Map<string, { summary: CompsSummary; expiresAt: number }>();
+const COMPS_TTL_MS = 10 * 60_000;
+const COMPS_CACHE_MAX = 200;
+
 // Search active comps for a listing. `appToken` comes from the taxonomy
 // module's client-credentials flow — the Browse API accepts the same scope.
 export async function searchComps(
@@ -117,6 +124,9 @@ export async function searchComps(
   if (!query) return empty;
 
   const wantNew = isNewGrade(listing.condition);
+  const cacheKey = `${query}|${wantNew ? "new" : "used"}`;
+  const cached = compsCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.summary;
   const params = new URLSearchParams({
     q: query,
     limit: "50",
@@ -134,7 +144,7 @@ export async function searchComps(
   const items: BrowseItem[] = data?.itemSummaries ?? [];
   const prices = filterComps(items, listing.condition);
   const stats = compStats(prices);
-  return {
+  const summary: CompsSummary = {
     ok: stats.count > 0,
     query,
     ...stats,
@@ -143,4 +153,7 @@ export async function searchComps(
         ? `${stats.count} active ${wantNew ? "new" : "pre-owned"} listings matching “${query}” (asking prices, not sold)`
         : "",
   };
+  if (compsCache.size > COMPS_CACHE_MAX) compsCache.clear();
+  compsCache.set(cacheKey, { summary, expiresAt: Date.now() + COMPS_TTL_MS });
+  return summary;
 }

--- a/lib/ebay/comps.ts
+++ b/lib/ebay/comps.ts
@@ -1,0 +1,146 @@
+// Comparable-listing price research via eBay's Browse API.
+//
+// The analysis model's suggested_price is a visual guess with no market data
+// behind it. This module grounds it: search active eBay listings for the same
+// kind of item, filter out bad comps (lots, wrong condition, parts,
+// reproductions), and compute a median/trimmed price band with a confidence
+// score. Active asking prices run higher than sold prices (eBay's sold-comps
+// API requires special approval), so this is a sanity band, not gospel — the
+// UI presents it beside the AI estimate and the seller decides.
+
+import { EBAY_MARKETPLACE_ID } from "./config";
+import type { CompsSummary, ListingResult } from "@/lib/types";
+
+const EBAY_BROWSE_SEARCH = "https://api.ebay.com/buy/browse/v1/item_summary/search";
+
+export type { CompsSummary };
+
+// Comps that poison the statistics: multi-item lots when ours is one item,
+// parts/repair listings, reproductions, and empty-box scams.
+const BAD_COMP_TITLE_RE =
+  /\b(lot(?:\sof)?|bundle|wholesale|reseller|bulk|x\s?\d{2,}|for\sparts|parts\sonly|repair|broken|damaged|repro(?:duction)?|replica|fake|style\sof|box\sonly|case\sonly|manual\sonly)\b/i;
+
+const NEW_CONDITION_IDS = new Set([1000, 1500, 1750]);
+
+function isNewGrade(condition: string | undefined): boolean {
+  return /^NEW/i.test(String(condition || ""));
+}
+
+export function buildCompQuery(listing: ListingResult): string {
+  const brand = String(listing.brand || "").trim();
+  const usableBrand = brand && !/^(no\s?brand|unbranded|unknown)$/i.test(brand) ? brand : "";
+  const itemType = String(listing.item_type || "").trim();
+  const parts = [usableBrand, itemType].filter(Boolean);
+  if (parts.length) return parts.join(" ").slice(0, 100);
+  // No brand/type — fall back to the first few title words.
+  return String(listing.title || "").split(/\s+/).slice(0, 6).join(" ").slice(0, 100);
+}
+
+interface BrowseItem {
+  title?: string;
+  price?: { value?: string; currency?: string };
+  conditionId?: string;
+  itemGroupType?: string;
+}
+
+export function filterComps(
+  items: BrowseItem[],
+  listingCondition: string | undefined
+): number[] {
+  const wantNew = isNewGrade(listingCondition);
+  const prices: number[] = [];
+  for (const it of items) {
+    const price = Number(it.price?.value);
+    if (!Number.isFinite(price) || price <= 0) continue;
+    if (it.price?.currency && it.price.currency !== "USD") continue;
+    if (BAD_COMP_TITLE_RE.test(String(it.title || ""))) continue;
+    const condId = Number(it.conditionId);
+    if (Number.isFinite(condId) && condId > 0) {
+      const compIsNew = NEW_CONDITION_IDS.has(condId);
+      if (compIsNew !== wantNew) continue;
+    }
+    prices.push(price);
+  }
+  return prices;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = (sorted.length - 1) * p;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  const frac = idx - lo;
+  return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+// Median, 10–90% band, trimmed mean, and a confidence heuristic based on how
+// many valid comps exist and how tightly they cluster.
+export function compStats(prices: number[]): Omit<CompsSummary, "ok" | "query" | "basis"> {
+  const sorted = [...prices].sort((a, b) => a - b);
+  const count = sorted.length;
+  if (count === 0) return { count: 0, confidence: 0 };
+
+  const median = percentile(sorted, 0.5);
+  const low = percentile(sorted, 0.1);
+  const high = percentile(sorted, 0.9);
+  const trimStart = Math.floor(count * 0.1);
+  const trimmed = sorted.slice(trimStart, count - trimStart || count);
+  const trimmedMean = trimmed.reduce((s, n) => s + n, 0) / trimmed.length;
+
+  // Confidence: volume (12+ comps → full marks) damped by dispersion — a band
+  // spanning 3× the median means the query matched too many different things.
+  const volumeScore = Math.min(1, count / 12);
+  const spread = median > 0 ? (high - low) / median : 1;
+  const tightness = Math.max(0.2, 1 - spread / 3);
+  const confidence = Math.round(volumeScore * tightness * 100) / 100;
+
+  return {
+    count,
+    median: round2(median),
+    trimmedMean: round2(trimmedMean),
+    low: round2(low),
+    high: round2(high),
+    confidence,
+  };
+}
+
+// Search active comps for a listing. `appToken` comes from the taxonomy
+// module's client-credentials flow — the Browse API accepts the same scope.
+export async function searchComps(
+  appToken: string,
+  listing: ListingResult
+): Promise<CompsSummary> {
+  const query = buildCompQuery(listing);
+  const empty: CompsSummary = { ok: false, query, count: 0, confidence: 0, basis: "" };
+  if (!query) return empty;
+
+  const wantNew = isNewGrade(listing.condition);
+  const params = new URLSearchParams({
+    q: query,
+    limit: "50",
+    filter: `buyingOptions:{FIXED_PRICE},conditions:{${wantNew ? "NEW" : "USED"}},priceCurrency:USD`,
+  });
+  const resp = await fetch(`${EBAY_BROWSE_SEARCH}?${params}`, {
+    headers: {
+      Authorization: `Bearer ${appToken}`,
+      Accept: "application/json",
+      "X-EBAY-C-MARKETPLACE-ID": EBAY_MARKETPLACE_ID,
+    },
+  });
+  if (!resp.ok) return empty;
+  const data = await resp.json().catch(() => null);
+  const items: BrowseItem[] = data?.itemSummaries ?? [];
+  const prices = filterComps(items, listing.condition);
+  const stats = compStats(prices);
+  return {
+    ok: stats.count > 0,
+    query,
+    ...stats,
+    basis:
+      stats.count > 0
+        ? `${stats.count} active ${wantNew ? "new" : "pre-owned"} listings matching “${query}” (asking prices, not sold)`
+        : "",
+  };
+}

--- a/lib/ebay/identifiers.ts
+++ b/lib/ebay/identifiers.ts
@@ -1,0 +1,127 @@
+// Product identifiers (UPC / EAN / ISBN / MPN) extracted from the analysis
+// model's item specifics, validated before they go anywhere near eBay.
+//
+// The Inventory API accepts these as dedicated product fields, and a valid
+// identifier lets eBay match the item to its catalog (established title,
+// aspects, and product page) — a big win for books, media, games, and boxed
+// products. Vintage one-off clothing has no identifiers, so nothing changes.
+
+import type { ListingResult } from "@/lib/types";
+import { isPlaceholderValue } from "./aspects";
+
+export interface ProductIdentifiers {
+  upc?: string;
+  ean?: string;
+  isbn?: string;
+  mpn?: string;
+}
+
+function digitsOnly(raw: string): string {
+  return raw.replace(/[\s\-–.]/g, "");
+}
+
+// GS1 check digit (UPC-A / EAN-13): weighted sum mod 10.
+function gs1CheckOk(code: string): boolean {
+  const digits = code.split("").map(Number);
+  const check = digits.pop()!;
+  let sum = 0;
+  // Weight 3 applies to alternating positions counted from the right.
+  digits.reverse().forEach((d, i) => {
+    sum += d * (i % 2 === 0 ? 3 : 1);
+  });
+  return (10 - (sum % 10)) % 10 === check;
+}
+
+export function validUpc(raw: string): string | null {
+  const code = digitsOnly(raw);
+  return /^\d{12}$/.test(code) && gs1CheckOk(code) ? code : null;
+}
+
+export function validEan(raw: string): string | null {
+  const code = digitsOnly(raw);
+  return /^\d{13}$/.test(code) && gs1CheckOk(code) ? code : null;
+}
+
+export function validIsbn(raw: string): string | null {
+  const code = digitsOnly(raw).toUpperCase();
+  if (/^\d{13}$/.test(code)) {
+    // ISBN-13 uses the same GS1 check and starts with the Bookland prefix.
+    return (code.startsWith("978") || code.startsWith("979")) && gs1CheckOk(code)
+      ? code
+      : null;
+  }
+  if (/^\d{9}[\dX]$/.test(code)) {
+    let sum = 0;
+    for (let i = 0; i < 10; i++) {
+      const c = code[i] === "X" ? 10 : Number(code[i]);
+      sum += c * (10 - i);
+    }
+    return sum % 11 === 0 ? code : null;
+  }
+  return null;
+}
+
+export function validMpn(raw: string): string | null {
+  const s = String(raw || "").trim();
+  if (!s || isPlaceholderValue(s) || s.length > 65) return null;
+  // An MPN needs at least one digit or letter and shouldn't be a sentence.
+  return /^[\w\-./#+ ]{2,65}$/.test(s) && !/\s{2,}|\w+\s+\w+\s+\w+\s+\w+/.test(s)
+    ? s
+    : null;
+}
+
+function specificValue(listing: ListingResult, ...keys: string[]): string {
+  const specifics = listing.item_specifics || {};
+  for (const [k, v] of Object.entries(specifics)) {
+    if (keys.some((key) => k.toLowerCase() === key.toLowerCase())) {
+      const s = String(v ?? "").trim();
+      if (s) return s;
+    }
+  }
+  return "";
+}
+
+// Pull whatever identifiers the photos actually showed. A 13-digit "UPC" is
+// really an EAN; a Bookland EAN doubles as the ISBN-13.
+export function extractProductIdentifiers(listing: ListingResult): ProductIdentifiers {
+  const out: ProductIdentifiers = {};
+
+  const upcRaw = specificValue(listing, "UPC", "Barcode");
+  if (upcRaw) {
+    const upc = validUpc(upcRaw);
+    if (upc) out.upc = upc;
+    else {
+      const ean = validEan(upcRaw);
+      if (ean) out.ean = ean;
+    }
+  }
+
+  const eanRaw = specificValue(listing, "EAN");
+  if (!out.ean && eanRaw) {
+    const ean = validEan(eanRaw);
+    if (ean) out.ean = ean;
+  }
+
+  const isbnRaw = specificValue(listing, "ISBN");
+  if (isbnRaw) {
+    const isbn = validIsbn(isbnRaw);
+    if (isbn) out.isbn = isbn;
+  }
+  if (!out.isbn && out.ean && (out.ean.startsWith("978") || out.ean.startsWith("979"))) {
+    out.isbn = out.ean;
+  }
+
+  const mpnRaw = specificValue(listing, "MPN", "Manufacturer Part Number", "Model Number");
+  if (mpnRaw) {
+    const mpn = validMpn(mpnRaw);
+    if (mpn) out.mpn = mpn;
+  }
+
+  return out;
+}
+
+// Catalog matching is only worth switching on when a strong identifier exists —
+// UPC/EAN/ISBN uniquely identify a product; an MPN alone is too fuzzy.
+export function hasCatalogIdentifier(ids: ProductIdentifiers): boolean {
+  return Boolean(ids.upc || ids.ean || ids.isbn);
+}

--- a/lib/ebay/identifiers.ts
+++ b/lib/ebay/identifiers.ts
@@ -20,6 +20,11 @@ function digitsOnly(raw: string): string {
   return raw.replace(/[\s\-–.]/g, "");
 }
 
+// All-zero codes pass the GS1 checksum but identify nothing real.
+function isAllZeros(code: string): boolean {
+  return /^0+$/.test(code);
+}
+
 // GS1 check digit (UPC-A / EAN-13): weighted sum mod 10.
 function gs1CheckOk(code: string): boolean {
   const digits = code.split("").map(Number);
@@ -34,12 +39,12 @@ function gs1CheckOk(code: string): boolean {
 
 export function validUpc(raw: string): string | null {
   const code = digitsOnly(raw);
-  return /^\d{12}$/.test(code) && gs1CheckOk(code) ? code : null;
+  return /^\d{12}$/.test(code) && !isAllZeros(code) && gs1CheckOk(code) ? code : null;
 }
 
 export function validEan(raw: string): string | null {
   const code = digitsOnly(raw);
-  return /^\d{13}$/.test(code) && gs1CheckOk(code) ? code : null;
+  return /^\d{13}$/.test(code) && !isAllZeros(code) && gs1CheckOk(code) ? code : null;
 }
 
 export function validIsbn(raw: string): string | null {

--- a/lib/ebay/publish.ts
+++ b/lib/ebay/publish.ts
@@ -10,13 +10,22 @@ import {
   EBAY_TRADING,
 } from "./config";
 import {
-  suggestLeafCategory,
+  suggestLeafCategories,
   categoryAspects,
   acceptedConditionIds,
   type AspectMeta,
 } from "./taxonomy";
-import { clipAspectValue, matchAllowed, canonicalizeAspectKeys } from "./aspects";
+import {
+  clipAspectValue,
+  cleanAspectValue,
+  splitAspectValues,
+  matchAllowed,
+  canonicalizeAspectKeys,
+  enforceCardinality,
+} from "./aspects";
 import { fillRecommendedAspects } from "./aspectFill";
+import { extractProductIdentifiers, hasCatalogIdentifier } from "./identifiers";
+import { parseMeasurements } from "@/lib/measurements";
 import { APPAREL_CATEGORIES, PANTS_CATEGORIES } from "@/lib/categories";
 import type { ListingResult } from "@/lib/types";
 
@@ -43,7 +52,12 @@ const CATEGORY_MAP: Record<string, string> = {
   stamp: "260", ephemera: "165800", other: "99",
 };
 
-const LEAF_FALLBACKS = ["1463", "22733", "2550", "48108", "316", "171485", "2624", "2613"];
+// NOTE: category fallbacks used to be a static list of unrelated collectible
+// leaves (dolls, plush, puzzles…) tried blindly whenever eBay rejected the
+// chosen category. Publishing a dress into "Puzzles" technically succeeds and
+// commercially fails — so fallbacks now come from eBay's own runner-up
+// category suggestions for THIS item, and when none work the publish stops
+// with an actionable error instead of landing in a wrong category.
 
 const CONDITION_ALIASES: Record<string, string> = {
   NEW: "NEW_WITH_TAGS",
@@ -182,36 +196,76 @@ async function ebayRequest(
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function computeBufferedPrice(raw: number | string | undefined): number {
-  let base = typeof raw === "string" ? parseFloat(raw) : raw ?? 0;
-  if (!base || Number.isNaN(base) || base <= 0) base = 29.99;
-  const buffered = Math.max(base * 1.18, base + 5);
-  return Math.round(buffered * 100) / 100;
+// The price the seller reviewed and approved is the price that publishes.
+// (This used to silently apply an 18% markup and quietly default a missing
+// price to $29.99 → $35.39 — hiding unidentified items behind a made-up
+// number instead of stopping for review.) Returns null when there is no
+// usable price, which blocks the publish with an actionable error.
+export function validListingPrice(raw: number | string | undefined): number | null {
+  const base = typeof raw === "string" ? parseFloat(raw) : raw;
+  if (base === undefined || Number.isNaN(base) || base <= 0) return null;
+  return Math.round(base * 100) / 100;
 }
 
 // eBay's CALCULATED-shipping business policies REQUIRE package weight (and
 // dimensions) on the inventory item, or publish fails with error 25020 ("package
-// weight is not valid or is missing"). Flat-rate policies don't need it. We always
-// send a sensible default so calculated policies publish out of the box; the
-// seller can refine weight/size on the listing afterward, or tune the defaults
-// via EBAY_DEFAULT_PACKAGE_* env vars. Weight is in ounces (16 oz = 1 lb).
-function defaultPackageWeightAndSize(): Record<string, unknown> {
+// weight is not valid or is missing"). Flat-rate policies don't need it.
+//
+// One 16 oz / 12×9×3 default for everything undercharged shipping badly for
+// coats, boots, appliances, and framed art, so defaults are now profiled by
+// item class. The seller can still refine weight/size on the listing afterward.
+// Explicitly-set EBAY_DEFAULT_PACKAGE_* env vars override every profile.
+// Weight is in ounces (16 oz = 1 lb); dimensions in inches.
+interface PackageProfile {
+  oz: number;
+  l: number;
+  w: number;
+  h: number;
+  type: string;
+}
+
+const DEFAULT_PACKAGE: PackageProfile = { oz: 16, l: 12, w: 9, h: 3, type: "PACKAGE_THICK_ENVELOPE" };
+
+const PACKAGE_PROFILES: Record<string, PackageProfile> = (() => {
+  const box = (oz: number, l: number, w: number, h: number): PackageProfile => ({
+    oz, l, w, h, type: "MAILING_BOX",
+  });
+  const profiles: Record<string, PackageProfile> = {};
+  const assign = (keys: string[], p: PackageProfile) =>
+    keys.forEach((k) => (profiles[k] = p));
+  assign(["womens_coat", "mens_coat"], box(40, 16, 12, 5));
+  assign(["womens_shoes", "mens_shoes"], box(48, 14, 10, 6));
+  assign(["handbag"], box(24, 14, 11, 4));
+  assign(
+    ["small_appliance", "electronics", "camera", "audio", "musical_instrument", "tool", "automotive", "kitchenware", "sporting_goods"],
+    box(48, 14, 11, 6)
+  );
+  assign(["art", "collector_plate"], box(48, 20, 16, 4));
+  assign(["glassware", "pottery_ceramics", "doll", "collectible", "holiday", "home_decor", "lighting"], box(32, 12, 10, 8));
+  assign(["book", "media", "cd", "dvd_bluray", "video_game"], { oz: 12, l: 12, w: 9, h: 2, type: "PACKAGE_THICK_ENVELOPE" });
+  assign(["vinyl_record"], { oz: 16, l: 14, w: 14, h: 2, type: "PACKAGE_THICK_ENVELOPE" });
+  assign(["linens", "plush"], box(20, 14, 11, 4));
+  return profiles;
+})();
+
+function defaultPackageWeightAndSize(catKey: string): Record<string, unknown> {
+  const profile = PACKAGE_PROFILES[catKey] ?? DEFAULT_PACKAGE;
   const num = (v: string | undefined, fallback: number) => {
     const n = Number(v);
     return Number.isFinite(n) && n > 0 ? n : fallback;
   };
   return {
     weight: {
-      value: num(process.env.EBAY_DEFAULT_PACKAGE_WEIGHT_OZ, 16),
+      value: num(process.env.EBAY_DEFAULT_PACKAGE_WEIGHT_OZ, profile.oz),
       unit: "OUNCE",
     },
     dimensions: {
-      length: num(process.env.EBAY_DEFAULT_PACKAGE_LENGTH_IN, 12),
-      width: num(process.env.EBAY_DEFAULT_PACKAGE_WIDTH_IN, 9),
-      height: num(process.env.EBAY_DEFAULT_PACKAGE_HEIGHT_IN, 3),
+      length: num(process.env.EBAY_DEFAULT_PACKAGE_LENGTH_IN, profile.l),
+      width: num(process.env.EBAY_DEFAULT_PACKAGE_WIDTH_IN, profile.w),
+      height: num(process.env.EBAY_DEFAULT_PACKAGE_HEIGHT_IN, profile.h),
       unit: "INCH",
     },
-    packageType: "PACKAGE_THICK_ENVELOPE",
+    packageType: profile.type,
   };
 }
 
@@ -274,35 +328,18 @@ function conditionCandidates(
   return out.length ? out : ["USED_GOOD"];
 }
 
-function resolveCategory(listing: ListingResult): {
-  categoryId: string;
-  fallbacks: string[];
-} {
+// Offline/static category resolution — used only when eBay's Taxonomy
+// suggestions are unavailable.
+function staticCategory(listing: ListingResult): string {
   const explicit = (listing.category_id || "").toString().trim();
   const catKey = (listing.category || "other").toString();
-  const mapped = CATEGORY_MAP[catKey] || CATEGORY_MAP.other;
-  const categoryId = explicit || mapped;
-  const fallbacks = LEAF_FALLBACKS.filter((c) => c && c !== categoryId);
-  return { categoryId, fallbacks };
+  return explicit || CATEGORY_MAP[catKey] || CATEGORY_MAP.other;
 }
 
+// First clean value of a possibly-compound field ("Cotton / Poly" → "Cotton").
+// Placeholder phrases ("See tag in photos") come back as "".
 function singleValue(v: unknown): string {
-  if (Array.isArray(v)) {
-    for (const x of v) {
-      const s = singleValue(x);
-      if (s) return s;
-    }
-    return "";
-  }
-  let s = String(v ?? "").trim();
-  if (!s) return "";
-  for (const sep of ["/", ",", "|", "&", " and "]) {
-    if (s.includes(sep)) {
-      s = s.split(sep)[0].trim();
-      break;
-    }
-  }
-  return s.replace(/\s+/g, " ");
+  return splitAspectValues(v)[0] || "";
 }
 
 function departmentForCategory(catKey: string): string {
@@ -311,40 +348,50 @@ function departmentForCategory(catKey: string): string {
   return "Unisex Adult";
 }
 
-// Build the item-specifics (aspects) map from the listing.
+// Build the item-specifics (aspects) map from the listing. Values are kept as
+// full arrays here ("Cotton / Polyester" → both parts survive); once eBay's
+// aspect metadata arrives, enforceCardinality() trims single-value aspects.
+// Placeholder phrases ("See tag in photos") never become aspect values —
+// cleanAspectValue/splitAspectValues drop them at the door.
 function buildAspects(listing: ListingResult, catKey: string): Record<string, string[]> {
   const aspects: Record<string, string[]> = {};
-  const put = (k: string, v: string) => {
-    const val = clipAspectValue(v);
+  const putOne = (k: string, v: string) => {
+    const val = cleanAspectValue(v);
     if (val) aspects[k] = [val];
   };
+  const putMany = (k: string, v: unknown) => {
+    const vals = splitAspectValues(v);
+    if (vals.length) aspects[k] = vals;
+  };
 
-  put("Brand", String(listing.brand || "").trim());
-  put("Size", cleanSize(listing.size));
-  put("Color", singleValue(listing.color));
-  put("Material", singleValue(listing.material));
-  put("Type", String(listing.item_type || "").trim());
+  putOne("Brand", String(listing.brand || "").trim());
+  putOne("Size", cleanSize(listing.size));
+  putMany("Color", listing.color);
+  putMany("Material", listing.material);
+  putOne("Type", String(listing.item_type || "").trim());
 
   const feats = Array.isArray(listing.key_features) ? listing.key_features : [];
-  const cleanFeats = feats.map((f) => clipAspectValue(String(f))).filter(Boolean).slice(0, 5);
+  const cleanFeats = feats.map((f) => cleanAspectValue(String(f))).filter(Boolean).slice(0, 5);
   if (cleanFeats.length) aspects.Features = cleanFeats;
 
   if (APPAREL_CATEGORIES.has(catKey) || catKey === "accessory") {
     aspects.Department = [departmentForCategory(catKey)];
   }
 
+  // Measurements go to eBay aspects only when explicitly labeled — never the
+  // whole free-text blob (which once produced Inseam = "Waist 32 in, rise 11…").
   if (PANTS_CATEGORIES.has(catKey)) {
-    const m = String(listing.measurements || "").trim();
-    if (m && m.toLowerCase() !== "see listing photos for measurements") {
-      aspects.Inseam = [m.slice(0, 30)];
-    }
+    const parsed = parseMeasurements(listing.measurements);
+    if (parsed.inseam) aspects.Inseam = [parsed.inseam];
+    if (parsed.waist && !aspects["Waist Size"]) aspects["Waist Size"] = [parsed.waist];
+    if (parsed.rise && !aspects.Rise) aspects.Rise = [parsed.rise];
   }
 
   // Merge in the model-provided item specifics (skip blanks + section labels).
   for (const [k, v] of Object.entries(listing.item_specifics || {})) {
     if (!k || k.startsWith("---")) continue;
-    const val = clipAspectValue(singleValue(v));
-    if (val && !aspects[k]) aspects[k] = [val];
+    const vals = splitAspectValues(v);
+    if (vals.length && !aspects[k]) aspects[k] = vals;
   }
   return aspects;
 }
@@ -378,14 +425,18 @@ function pickDepartment(allowed: string[], listing: ListingResult, catKey: strin
 
 // Best free-text fill for a required aspect we don't already have, drawn from
 // the listing itself. eBay accepts any string for FREE_TEXT aspects.
+// "Unbranded"/"Multicolor" are eBay's own canonical values for genuinely
+// unbranded/multicolored items; placeholder phrases are filtered out so
+// "See tag in photos" can never become a searchable specific.
 function freeTextDefault(name: string, listing: ListingResult): string {
   const n = name.toLowerCase();
-  if (n.includes("brand")) return String(listing.brand || "").trim() || "Unbranded";
+  const clean = (v: unknown) => cleanAspectValue(String(v ?? "").trim());
+  if (n.includes("brand")) return clean(listing.brand) || "Unbranded";
   if (n.includes("color")) return singleValue(listing.color) || "Multicolor";
   if (n.includes("shoe size") || n === "size") return cleanSize(listing.size);
-  if (n.includes("material")) return singleValue(listing.material) || "Man Made";
-  if (n.includes("style")) return String(listing.item_specifics?.Style || listing.item_type || "").trim();
-  if (n.includes("type")) return String(listing.item_type || "").trim();
+  if (n.includes("material")) return singleValue(listing.material);
+  if (n.includes("style")) return clean(listing.item_specifics?.Style || listing.item_type);
+  if (n.includes("type")) return clean(listing.item_type);
   return "";
 }
 
@@ -398,29 +449,38 @@ function reconcileAspects(
 ): void {
   for (const a of meta) {
     if (!a.required || !a.name) continue;
-    const current = aspects[a.name]?.[0];
+    const current = aspects[a.name] ?? [];
 
     if (a.mode === "SELECTION_ONLY") {
       // Must be one of eBay's allowed values, or the publish 25002-fails.
+      // Keep every valid value the listing already has (MULTI aspects may
+      // legitimately carry several).
+      const valid: string[] = [];
+      for (const v of current) {
+        const m = matchAllowed(v, a.values);
+        if (m && !valid.includes(m)) valid.push(m);
+      }
+      if (valid.length) {
+        aspects[a.name] = valid;
+        continue;
+      }
       // Size aspects never fall back to a guessed value — a wrong size
       // mislabels the item and trips eBay's standardization enforcement.
-      const canonical =
-        matchAllowed(current || "", a.values) ||
-        (isSizeAspect(a.name)
-          ? ""
-          : matchAllowed(ASPECT_DEFAULTS[a.name] || "", a.values) ||
-            (a.name === "Department" ? pickDepartment(a.values, listing, catKey) : "") ||
-            a.values[0] ||
-            "");
+      const canonical = isSizeAspect(a.name)
+        ? ""
+        : matchAllowed(ASPECT_DEFAULTS[a.name] || "", a.values) ||
+          (a.name === "Department" ? pickDepartment(a.values, listing, catKey) : "") ||
+          a.values[0] ||
+          "";
       if (canonical) aspects[a.name] = [canonical];
       else if (isSizeAspect(a.name)) delete aspects[a.name];
-    } else if (!current) {
+    } else if (!current.length) {
       // FREE_TEXT and unset — fill from the listing or a sensible default.
       const fromListing = freeTextDefault(a.name, listing);
       const v =
         fromListing ||
         (isSizeAspect(a.name) ? "" : ASPECT_DEFAULTS[a.name] || a.values[0] || "");
-      const clipped = clipAspectValue(v);
+      const clipped = clipAspectValue(v, a.maxLength);
       if (clipped) aspects[a.name] = [clipped];
     }
   }
@@ -536,14 +596,20 @@ function extractMissingAspects(r: EbayResp): string[] {
 
 function addMissingAspects(
   aspects: Record<string, string[]>,
-  missing: string[]
+  missing: string[],
+  listing: ListingResult
 ): string[] {
   const added: string[] = [];
   for (const field of missing) {
     // Never stamp a default into a size aspect — let eBay's "missing item
     // specific" error surface so the seller supplies the real size.
     if (isSizeAspect(field)) continue;
-    const def = ASPECT_DEFAULTS[field] || "Unbranded";
+    // Real listing data or a known safe default only. Stamping "Unbranded"
+    // into arbitrary fields (the old fallback) produced junk like
+    // Type = "Unbranded"; if nothing sensible exists, let eBay's error
+    // surface and tell the seller exactly which specific is missing.
+    const def = ASPECT_DEFAULTS[field] || freeTextDefault(field, listing);
+    if (!def) continue;
     aspects[field] = [def];
     added.push(`${field}=${def}`);
   }
@@ -684,6 +750,16 @@ export interface PublishResult {
   // The SKU already has a LIVE eBay listing — a duplicate bin batch, not a
   // transient failure. The client uses this to avoid clobbering the earlier item.
   alreadyListed?: boolean;
+  // Non-fatal quality problems (e.g. eBay's aspect schema couldn't be
+  // retrieved, so the listing published with generic specifics). Surfaced in
+  // the UI so degraded listings stop failing silently.
+  warnings?: string[];
+}
+
+// EBAY_STRICT_QUALITY=1 turns quality warnings into publish failures: better a
+// stopped listing than one that quietly published without searchable specifics.
+function strictQualityMode(): boolean {
+  return process.env.EBAY_STRICT_QUALITY === "1" || /^true$/i.test(process.env.EBAY_STRICT_QUALITY || "");
 }
 
 const CL = { "Content-Language": "en-US" };
@@ -744,11 +820,34 @@ export async function publishListing(
 ): Promise<PublishResult> {
   const { sku, listing } = input;
   const catKey = String(listing.category || "other");
-  const { categoryId: staticCat, fallbacks } = resolveCategory(listing);
-  // Ask eBay for the real LEAF category from the title + hint; fall back to the
-  // static map only if Taxonomy is unavailable. (Fixes 25005 non-leaf errors.)
-  const leaf = await suggestLeafCategory(`${listing.category_hint || ""} ${listing.title || ""}`);
-  let catId = leaf || staticCat;
+  const warnings: string[] = [];
+
+  // The seller-reviewed price publishes as-is — no hidden markup, no invented
+  // default. A listing with no usable price stops here for review.
+  const price = validListingPrice(listing.suggested_price);
+  if (price === null) {
+    return {
+      success: false,
+      sku,
+      error:
+        "This listing has no price. Set a price on the listing card before posting — the analysis couldn't estimate one, and posting with a made-up default would misprice the item.",
+    };
+  }
+
+  // Ask eBay for the real LEAF category from the title + hint; the runners-up
+  // become *relevant* fallbacks if eBay rejects the first pick. Fall back to
+  // the static map only if Taxonomy is unavailable. (Fixes 25005 non-leaf errors.)
+  const suggestions = await suggestLeafCategories(
+    `${listing.category_hint || ""} ${listing.title || ""}`,
+    3
+  );
+  let catId = suggestions[0]?.id || staticCategory(listing);
+  const fallbacks = suggestions.slice(1).map((s) => s.id);
+  if (!suggestions.length) {
+    warnings.push(
+      "eBay's category suggestions were unavailable — used the offline category map, which may be less precise."
+    );
+  }
 
   if (!setup.fulfillmentPolicyId || !setup.paymentPolicyId || !setup.returnPolicyId) {
     return {
@@ -783,7 +882,9 @@ export async function publishListing(
   const aspects = buildAspects(listing, catKey);
   // Ask eBay (in parallel) for the leaf category's specifics and its accepted
   // condition ids, then make both valid before creating the item.
-  // Non-fatal: the recovery loops below remain as a backup if eBay is slow.
+  // Non-fatal by default: the recovery loops below remain as a backup if eBay
+  // is slow — but the degradation is now VISIBLE (warning or, in strict
+  // quality mode, a hard stop) instead of silently publishing generic data.
   let acceptedConds = new Set<number>();
   let aspectMeta: AspectMeta[] = [];
   try {
@@ -800,12 +901,27 @@ export async function publishListing(
     }
     acceptedConds = conds;
   } catch {
-    /* taxonomy/metadata unavailable — proceed with best-effort values */
+    /* taxonomy/metadata unavailable — handled just below */
   }
-  // Fill the remaining recommended specifics from the listing data (one cheap
-  // text-only model call) so live listings stop showing "suggested" aspects.
-  if (aspectMeta.length) {
-    await fillRecommendedAspects(listing, aspects, aspectMeta, sku);
+  if (!aspectMeta.length) {
+    const msg =
+      "eBay's item-specifics schema for this category couldn't be retrieved, so searchable specifics may be incomplete.";
+    if (strictQualityMode()) {
+      return {
+        success: false,
+        sku,
+        error: `${msg} Strict quality mode is on (EBAY_STRICT_QUALITY) — try again in a minute.`,
+      };
+    }
+    console.warn(`[ebay/publish] sku=${sku} category=${catId}: ${msg}`);
+    warnings.push(msg);
+  } else {
+    // Category-aware pass with the ORIGINAL PHOTOS + eBay's exact aspect
+    // schema — recovers details (model numbers, fabric contents, necklines…)
+    // that the first, schema-blind analysis missed.
+    await fillRecommendedAspects(listing, aspects, aspectMeta, sku, input.images);
+    // Trim every aspect to a legal value count now that cardinality is known.
+    enforceCardinality(aspects, aspectMeta);
   }
   const condCandidates = conditionCandidates(listing.condition, acceptedConds, catKey);
   const condition = condCandidates[0] || "USED_EXCELLENT";
@@ -813,18 +929,26 @@ export async function publishListing(
     `[ebay/publish] sku=${sku} category=${catId} grade=${listing.condition} → condition=${condition}` +
       (acceptedConds.size ? "" : " (no condition metadata — category-key fallback)")
   );
+  // Real product identifiers (validated UPC/EAN/ISBN/MPN) ride along so eBay
+  // can catalog-match commodity items; one-off vintage pieces have none.
+  const identifiers = extractProductIdentifiers(listing);
   const inventoryItem: any = {
     product: {
       title: String(listing.title || "Untitled").slice(0, 80),
       description: listing.description || "",
       aspects,
       imageUrls: photoUrls.slice(0, 12),
+      ...(identifiers.upc ? { upc: [identifiers.upc] } : {}),
+      ...(identifiers.ean ? { ean: [identifiers.ean] } : {}),
+      ...(identifiers.isbn ? { isbn: [identifiers.isbn] } : {}),
+      ...(identifiers.mpn ? { mpn: identifiers.mpn } : {}),
     },
     condition,
     conditionDescription: listing.condition_notes || "",
     availability: { shipToLocationAvailability: { quantity: 1 } },
-    // Default weight/size so CALCULATED-shipping policies publish (eBay 25020).
-    packageWeightAndSize: defaultPackageWeightAndSize(),
+    // Class-profiled weight/size so CALCULATED-shipping policies publish
+    // (eBay 25020) without a coat shipping as a 1-lb envelope.
+    packageWeightAndSize: defaultPackageWeightAndSize(catKey),
   };
 
   const putInventory = () =>
@@ -841,7 +965,7 @@ export async function publishListing(
   let r = await putInventory();
   if (![200, 201, 204].includes(r.status)) {
     const missing = extractMissingAspects(r);
-    if (missing.length && addMissingAspects(aspects, missing).length) {
+    if (missing.length && addMissingAspects(aspects, missing, listing).length) {
       inventoryItem.product.aspects = aspects;
       r = await putInventory();
     }
@@ -871,7 +995,6 @@ export async function publishListing(
   }
 
   // 3. Offer.
-  const price = computeBufferedPrice(listing.suggested_price);
   const offerBody: any = {
     sku,
     marketplaceId: EBAY_MARKETPLACE_ID,
@@ -886,7 +1009,10 @@ export async function publishListing(
       paymentPolicyId: setup.paymentPolicyId,
       returnPolicyId: setup.returnPolicyId,
     },
-    includeCatalogProductDetails: false,
+    // Catalog matching helps commodity items (books, media, boxed products)
+    // inherit eBay's established product data — but only when a strong,
+    // validated identifier ties this item to one catalog product.
+    includeCatalogProductDetails: hasCatalogIdentifier(identifiers),
   };
 
   const postOffer = () =>
@@ -904,13 +1030,15 @@ export async function publishListing(
 
   // Recovery: missing aspects during offer create.
   if (![200, 201].includes(r.status) && extractMissingAspects(r).length) {
-    if (addMissingAspects(aspects, extractMissingAspects(r)).length) {
+    if (addMissingAspects(aspects, extractMissingAspects(r), listing).length) {
       inventoryItem.product.aspects = aspects;
       await putInventory();
       r = await postOffer();
     }
   }
-  // Recovery: non-leaf category (25005).
+  // Recovery: category rejected (25005) → try eBay's OWN runner-up suggestions
+  // for this item. Never unrelated generic categories: a wrong-category
+  // publication is worse than a stopped listing.
   if (![200, 201].includes(r.status) && errorIds(r).includes(25005)) {
     for (const fb of fallbacks) {
       offerBody.categoryId = fb;
@@ -920,6 +1048,16 @@ export async function publishListing(
         catId = fb;
         break;
       }
+    }
+    if (![200, 201].includes(r.status) && !extractExistingOfferId(r)) {
+      logPublishFailure("offer creation", sku, r);
+      return {
+        success: false,
+        sku,
+        error:
+          `eBay rejected the category for this item (tried ${[catId, ...fallbacks].join(", ")}). ` +
+          "Rather than publishing it in an unrelated category, this listing was stopped — adjust the title or re-analyze so the category suggestion improves, or post it manually.",
+      };
     }
   }
 
@@ -958,11 +1096,13 @@ export async function publishListing(
     offerId,
     catId,
     catKey,
+    listing,
     aspects,
     inventoryItem,
     offerBody,
     fallbacks,
     condCandidates,
+    warnings,
   });
 }
 
@@ -973,14 +1113,17 @@ async function publishOfferWithRecovery(
     offerId: string;
     catId: string;
     catKey: string;
+    listing: ListingResult;
     aspects: Record<string, string[]>;
     inventoryItem: any;
     offerBody: any;
     fallbacks: string[];
     condCandidates: string[];
+    warnings: string[];
   }
 ): Promise<PublishResult> {
   const { sku, offerId } = ctx;
+  const warnings = ctx.warnings.length ? ctx.warnings : undefined;
   const doPublish = () =>
     withTransientRetry(
       () =>
@@ -1002,7 +1145,7 @@ async function publishOfferWithRecovery(
     );
 
   let r = await doPublish();
-  if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "" };
+  if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "", warnings };
 
   // The offer already went live (e.g. an earlier attempt timed out after the
   // publish landed). That's success — recover the listing id and report it.
@@ -1020,11 +1163,11 @@ async function publishOfferWithRecovery(
 
   // Recovery: missing item specifics.
   const missing = extractMissingAspects(r);
-  if (missing.length && addMissingAspects(ctx.aspects, missing).length) {
+  if (missing.length && addMissingAspects(ctx.aspects, missing, ctx.listing).length) {
     ctx.inventoryItem.product.aspects = ctx.aspects;
     await putInventory();
     r = await doPublish();
-    if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "" };
+    if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "", warnings };
     eids = errorIds(r);
   }
 
@@ -1039,7 +1182,7 @@ async function publishOfferWithRecovery(
       ctx.inventoryItem.condition = alt;
       await putInventory();
       r = await doPublish();
-      if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "" };
+      if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "", warnings };
       eids = errorIds(r);
       if (!eids.includes(25021) && !eids.includes(25059)) break;
     }
@@ -1054,7 +1197,7 @@ async function publishOfferWithRecovery(
       });
       if ([200, 201, 204].includes(upd.status)) {
         r = await doPublish();
-        if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "" };
+        if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "", warnings };
       }
     }
   }

--- a/lib/ebay/publish.ts
+++ b/lib/ebay/publish.ts
@@ -915,6 +915,12 @@ export async function publishListing(
     }
     console.warn(`[ebay/publish] sku=${sku} category=${catId}: ${msg}`);
     warnings.push(msg);
+    // Without eBay's schema we can't prove any aspect accepts multiple values —
+    // collapse to one (the long-standing safe behavior). Features is the known
+    // exception: eBay accepts several everywhere it exists.
+    for (const k of Object.keys(aspects)) {
+      if (k !== "Features" && aspects[k].length > 1) aspects[k] = aspects[k].slice(0, 1);
+    }
   } else {
     // Category-aware pass with the ORIGINAL PHOTOS + eBay's exact aspect
     // schema — recovers details (model numbers, fabric contents, necklines…)
@@ -1011,8 +1017,12 @@ export async function publishListing(
     },
     // Catalog matching helps commodity items (books, media, boxed products)
     // inherit eBay's established product data — but only when a strong,
-    // validated identifier ties this item to one catalog product.
-    includeCatalogProductDetails: hasCatalogIdentifier(identifiers),
+    // validated identifier ties this item to one catalog product AND the item
+    // class is commodity-like. A checksum-valid barcode on a collectible's
+    // repro box shouldn't overwrite the listing with the wrong catalog entry.
+    includeCatalogProductDetails:
+      hasCatalogIdentifier(identifiers) &&
+      ["media", "hard_goods"].includes(String(listing.item_profile || "")),
   };
 
   const postOffer = () =>
@@ -1040,6 +1050,15 @@ export async function publishListing(
   // for this item. Never unrelated generic categories: a wrong-category
   // publication is worse than a stopped listing.
   if (![200, 201].includes(r.status) && errorIds(r).includes(25005)) {
+    // The initial suggestion call may have failed (offline static map used,
+    // possibly non-leaf). Taxonomy might be back by now — ask once more.
+    if (!fallbacks.length) {
+      const retry = await suggestLeafCategories(
+        `${listing.category_hint || ""} ${listing.title || ""}`,
+        3
+      );
+      fallbacks.push(...retry.map((s) => s.id).filter((id) => id !== catId));
+    }
     for (const fb of fallbacks) {
       offerBody.categoryId = fb;
       const fbResp = await postOffer();
@@ -1156,6 +1175,7 @@ async function publishOfferWithRecovery(
       sku,
       offerId,
       listingId: String(off.json?.listing?.listingId || ""),
+      warnings,
     };
   }
 

--- a/lib/ebay/taxonomy.ts
+++ b/lib/ebay/taxonomy.ts
@@ -23,19 +23,33 @@ import {
 } from "./config";
 
 export type AspectMode = "FREE_TEXT" | "SELECTION_ONLY";
+export type AspectUsage = "REQUIRED" | "RECOMMENDED" | "OPTIONAL";
+export type AspectCardinality = "SINGLE" | "MULTI";
 
 export interface AspectMeta {
   name: string;
   required: boolean;
+  usage: AspectUsage;
   mode: AspectMode;
+  // eBay allows one value or several for this aspect. Flattening a MULTI aspect
+  // ("Cotton/Polyester") to its first value loses searchable data.
+  cardinality: AspectCardinality;
+  maxLength?: number;
   values: string[]; // eBay's allowed/suggested values (full list for SELECTION_ONLY)
+}
+
+export interface CategorySuggestion {
+  id: string;
+  name: string;
 }
 
 // ── App token (client-credentials), cached in the warm lambda ────────────────
 
 let cachedToken: { token: string; expiresAt: number } | null = null;
 
-async function appToken(): Promise<string> {
+// Exported for other read-only eBay APIs that accept the same client-credentials
+// scope (e.g. Browse-API comp searches).
+export async function appToken(): Promise<string> {
   const now = Date.now();
   if (cachedToken && cachedToken.expiresAt > now + 60_000) return cachedToken.token;
   const creds = getEbayCreds();
@@ -74,18 +88,34 @@ async function taxGet(path: string): Promise<any | null> {
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
-// Resolve the best LEAF category id for a free-text query (title + hint).
-// eBay only suggests leaf categories, so the top hit is always publish-safe.
-export async function suggestLeafCategory(query: string): Promise<string | null> {
+// Resolve the best LEAF categories for a free-text query (title + hint), best
+// match first. eBay only suggests leaf categories, so every hit is publish-safe.
+// The runners-up double as *relevant* fallbacks if eBay rejects the first pick —
+// far better than the old static list of unrelated collectible categories.
+export async function suggestLeafCategories(
+  query: string,
+  limit = 3
+): Promise<CategorySuggestion[]> {
   const q = (query || "").trim().slice(0, 350);
-  if (!q) return null;
+  if (!q) return [];
   try {
     const data = await taxGet(`get_category_suggestions?q=${encodeURIComponent(q)}`);
-    const id = data?.categorySuggestions?.[0]?.category?.categoryId;
-    return id ? String(id) : null;
+    const out: CategorySuggestion[] = [];
+    for (const s of data?.categorySuggestions ?? []) {
+      const id = s?.category?.categoryId;
+      if (!id) continue;
+      out.push({ id: String(id), name: String(s?.category?.categoryName ?? "") });
+      if (out.length >= limit) break;
+    }
+    return out;
   } catch {
-    return null;
+    return [];
   }
+}
+
+export async function suggestLeafCategory(query: string): Promise<string | null> {
+  const suggestions = await suggestLeafCategories(query, 1);
+  return suggestions[0]?.id ?? null;
 }
 
 const aspectCache = new Map<string, AspectMeta[]>();
@@ -104,10 +134,20 @@ export async function categoryAspects(categoryId: string): Promise<AspectMeta[]>
       const con = a?.aspectConstraint ?? {};
       const name = String(a?.localizedAspectName ?? "").trim();
       if (!name) continue;
+      const required = Boolean(con?.aspectRequired);
+      const maxLen = Number(con?.aspectMaxLength);
       out.push({
         name,
-        required: Boolean(con?.aspectRequired),
+        required,
+        usage: required
+          ? "REQUIRED"
+          : con?.aspectUsage === "RECOMMENDED"
+            ? "RECOMMENDED"
+            : "OPTIONAL",
         mode: con?.aspectMode === "SELECTION_ONLY" ? "SELECTION_ONLY" : "FREE_TEXT",
+        cardinality:
+          con?.itemToAspectCardinality === "MULTI" ? "MULTI" : "SINGLE",
+        maxLength: Number.isFinite(maxLen) && maxLen > 0 ? maxLen : undefined,
         values: (a?.aspectValues ?? [])
           .map((v: any) => String(v?.localizedValue ?? "").trim())
           .filter(Boolean),

--- a/lib/measurements.ts
+++ b/lib/measurements.ts
@@ -1,0 +1,61 @@
+// Structured parsing of the free-text `measurements` field the analysis model
+// returns ("Waist 32 in, rise 11 in, inseam 29 in"). Publishing used to stuff
+// the first 30 characters of that whole string into eBay's Inseam aspect —
+// producing garbage like Inseam = "Waist 32 in, rise 11 in, ins". Now a
+// measurement is only mapped to an eBay aspect when it was explicitly labeled.
+
+export interface ParsedMeasurements {
+  inseam?: string;
+  waist?: string;
+  rise?: string;
+  chest?: string;
+  length?: string;
+  shoulder?: string;
+  sleeve?: string;
+  hip?: string;
+}
+
+// Each measurement key with the label spellings sellers/models actually use.
+const MEASUREMENT_LABELS: [keyof ParsedMeasurements, RegExp][] = [
+  ["inseam", /\binseam\b/i],
+  ["waist", /\bwaist\b/i],
+  ["rise", /\brise\b/i],
+  ["chest", /\b(?:chest|bust|pit[\s-]?to[\s-]?pit|armpit[\s-]?to[\s-]?armpit|p2p)\b/i],
+  ["shoulder", /\bshoulders?\b/i],
+  ["sleeve", /\bsleeves?\b/i],
+  ["hip", /\bhips?\b/i],
+  ["length", /\b(?:length|long)\b/i],
+];
+
+// A numeric measurement with optional fraction and unit: 29, 29.5, 29 1/2, 29", 29 in.
+const VALUE_RE = /(\d{1,3}(?:\.\d+)?(?:\s+\d\/\d)?)\s*(?:"|″|''|in(?:ch(?:es)?)?\.?\b|cm\b)?/;
+
+function normalizeValue(raw: string, unitHint: string): string {
+  const cm = /cm/i.test(unitHint);
+  return `${raw.trim()} ${cm ? "cm" : "in"}`;
+}
+
+// Parse labeled measurements out of free text. Only values directly attached
+// to a recognized label are returned — an unlabeled "29" is ignored rather
+// than guessed at.
+export function parseMeasurements(text: string | undefined): ParsedMeasurements {
+  const out: ParsedMeasurements = {};
+  const t = String(text || "").trim();
+  if (!t) return out;
+
+  for (const [key, labelRe] of MEASUREMENT_LABELS) {
+    if (out[key]) continue;
+    // Label followed (within a few chars: ":", "-", "of", "is", "approx") by a value.
+    const re = new RegExp(
+      labelRe.source + String.raw`[\s:=~-]*(?:approx\.?|about|is|of)?[\s:=~-]*` + VALUE_RE.source,
+      "i"
+    );
+    const m = re.exec(t);
+    if (!m) continue;
+    // The numeric value is the only capture group in the combined pattern.
+    const num = [...m].slice(1).reverse().find((g) => g && /^\d/.test(g));
+    if (!num) continue;
+    out[key] = normalizeValue(num, m[0]);
+  }
+  return out;
+}

--- a/lib/measurements.ts
+++ b/lib/measurements.ts
@@ -27,8 +27,11 @@ const MEASUREMENT_LABELS: [keyof ParsedMeasurements, RegExp][] = [
   ["length", /\b(?:length|long)\b/i],
 ];
 
-// A numeric measurement with optional fraction and unit: 29, 29.5, 29 1/2, 29", 29 in.
-const VALUE_RE = /(\d{1,3}(?:\.\d+)?(?:\s+\d\/\d)?)\s*(?:"|″|''|in(?:ch(?:es)?)?\.?\b|cm\b)?/;
+// A numeric measurement with optional fraction, range ("70-72"), and unit:
+// 29, 29.5, 29 1/2, 29-30, 29", 29 in, 70 cm. The range must be consumed so
+// the unit that FOLLOWS it is attributed correctly ("70-72 cm" is cm, not in).
+const VALUE_RE =
+  /(\d{1,3}(?:\.\d+)?(?:\s+\d\/\d)?)(?:\s*[-–~]\s*\d{1,3}(?:\.\d+)?)?\s*(?:"|″|''|in(?:ch(?:es)?)?\.?\b|cm\b)?/;
 
 function normalizeValue(raw: string, unitHint: string): string {
   const cm = /cm/i.test(unitHint);

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -102,10 +102,10 @@ Return ONLY valid JSON — no markdown, no code fences, no explanation. Use this
   "item_type": "Specific descriptive item type",
   "color": ["Primary color", "Secondary color if present — omit if solid"],
   "size": "Size EXACTLY as printed on the tag. If no size tag is visible but visible measurements clearly indicate one standard size, give that standard size (e.g. 'M', '32x34', '10.5'). Otherwise use an empty string — NEVER write placeholder text like 'See photos', 'Unknown', or 'N/A' (eBay blocks apparel listings with non-standard size values).",
-  "material": "Fabric or material composition as shown on tag. Write 'See tag in photos' if unclear.",
+  "material": "Fabric or material composition as shown on tag. Use an empty string if unclear — NEVER placeholder text like 'See tag in photos' (that belongs in the description, not a searchable field).",
   "condition": "One of: NEW_WITH_TAGS, NEW_NO_TAGS, EXCELLENT, VERY_GOOD, GOOD, FAIR",
   "condition_notes": "Honest 2-3 sentence condition description for buyers.",
-  "measurements": "Any measurements visible in photos, formatted clearly. Write 'See listing photos for measurements' if none visible.",
+  "measurements": "Measurements visible in photos, each with its label (e.g. 'Pit to pit 21 in, length 27 in' or 'Waist 32 in, rise 11 in, inseam 29 in'). Use an empty string if none visible — no placeholder text.",
   "description": "Full eBay listing description — plain text only, no markdown.",
   "suggested_price": 0.00,
   "seo_keywords": ["Up to 10 search phrases buyers would use"],
@@ -198,7 +198,7 @@ Return ONLY valid JSON — no markdown, no code fences, no explanation. Use this
 
 For title: Make it read like a strong live eBay title, using the most searchable nouns, brand, model, type, material, size, era, character, theme, or pattern when supported by the photos.
 For condition: Do NOT use LIKE_NEW. If an item is near mint but preowned, use EXCELLENT instead.
-For suggested_price: Price realistically for what this exact item sells for on eBay. Be honest.
+For suggested_price: Price realistically for what this exact item sells for on eBay. Be honest. If the item can't be identified well enough to price it, use 0 — the seller will price it manually (a wrong guess is worse than no guess).
 For item_specifics: Only include fields relevant to this item. Leave any field blank ("") if not applicable or unknown — do NOT guess. Omit all section-label keys (the ones that look like "--- TOPS ---") from your response.
 For category/category_hint: The broad category can be approximate, but the category_hint should help eBay find the exact leaf category for whatever type of item this is.
 For all item types: include as many accurate specifics as the photos support, even for non-clothing items such as collectibles, media, home decor, toys, tools, sporting goods, art, kitchenware, and electronics accessories.`;

--- a/lib/titleOptimizer.ts
+++ b/lib/titleOptimizer.ts
@@ -1,0 +1,67 @@
+// Deterministic eBay-title cleanup, applied right after analysis so the title
+// the seller reviews IS the title that publishes (no silent rewriting later).
+//
+// Conservative on purpose: it never reorders or drops the model's words except
+// exact duplicates, and only appends high-value identifiers (brand, size,
+// color) the model left out when there's room under eBay's 80-character cap.
+
+import type { ListingResult } from "@/lib/types";
+import { APPAREL_CATEGORIES } from "@/lib/categories";
+
+export const EBAY_TITLE_LIMIT = 80;
+
+// Words whose duplication is meaningful ("2 x 4", "Size 8 Wide 8.5").
+const DUP_EXEMPT_RE = /^\d|^(x|xs|s|m|l|xl|xxl)$/i;
+
+function dedupeWords(title: string): string {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const word of title.split(/\s+/)) {
+    const key = word.toLowerCase().replace(/[^\w'&.-]/g, "");
+    if (key && !DUP_EXEMPT_RE.test(key)) {
+      if (seen.has(key)) continue;
+      seen.add(key);
+    }
+    out.push(word);
+  }
+  return out.join(" ");
+}
+
+function clipAtWord(title: string, limit: number): string {
+  if (title.length <= limit) return title;
+  const cut = title.slice(0, limit);
+  const lastSpace = cut.lastIndexOf(" ");
+  return (lastSpace > limit * 0.6 ? cut.slice(0, lastSpace) : cut).trim();
+}
+
+function containsToken(title: string, token: string): boolean {
+  return title.toLowerCase().includes(token.toLowerCase());
+}
+
+// Candidate identifiers buyers search by, in append-priority order.
+function missingTokens(listing: ListingResult, title: string): string[] {
+  const tokens: string[] = [];
+  const brand = String(listing.brand || "").trim();
+  if (brand && !/^(no\s?brand|unbranded|unknown)$/i.test(brand) && !containsToken(title, brand)) {
+    tokens.push(brand);
+  }
+  const size = String(listing.size || "").trim();
+  const isApparel = APPAREL_CATEGORIES.has(String(listing.category || ""));
+  if (size && isApparel && !containsToken(title, size)) {
+    // "Sz M" reads naturally in eBay titles and disambiguates from bare letters.
+    tokens.push(size.length <= 4 ? `Sz ${size}` : size);
+  }
+  const color = Array.isArray(listing.color) ? listing.color[0] : listing.color;
+  const colorStr = String(color || "").trim();
+  if (colorStr && !containsToken(title, colorStr)) tokens.push(colorStr);
+  return tokens;
+}
+
+export function optimizeTitle(listing: ListingResult): string {
+  let title = dedupeWords(String(listing.title || "").replace(/\s+/g, " ").trim());
+  for (const token of missingTokens(listing, title)) {
+    if (title.length + 1 + token.length > EBAY_TITLE_LIMIT) continue;
+    title = `${title} ${token}`;
+  }
+  return clipAtWord(title, EBAY_TITLE_LIMIT);
+}

--- a/lib/titleOptimizer.ts
+++ b/lib/titleOptimizer.ts
@@ -1,31 +1,16 @@
 // Deterministic eBay-title cleanup, applied right after analysis so the title
 // the seller reviews IS the title that publishes (no silent rewriting later).
 //
-// Conservative on purpose: it never reorders or drops the model's words except
-// exact duplicates, and only appends high-value identifiers (brand, size,
-// color) the model left out when there's room under eBay's 80-character cap.
+// Conservative on purpose: it NEVER removes or reorders the model's words —
+// word-dedupe was tried and corrupted real names ("BOSS Hugo Boss",
+// "Johnson & Johnson", "Duran Duran"). It only appends high-value identifiers
+// (brand, size, color) the model left out when there's room under eBay's
+// 80-character cap, then clips at a word boundary.
 
 import type { ListingResult } from "@/lib/types";
 import { APPAREL_CATEGORIES } from "@/lib/categories";
 
 export const EBAY_TITLE_LIMIT = 80;
-
-// Words whose duplication is meaningful ("2 x 4", "Size 8 Wide 8.5").
-const DUP_EXEMPT_RE = /^\d|^(x|xs|s|m|l|xl|xxl)$/i;
-
-function dedupeWords(title: string): string {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const word of title.split(/\s+/)) {
-    const key = word.toLowerCase().replace(/[^\w'&.-]/g, "");
-    if (key && !DUP_EXEMPT_RE.test(key)) {
-      if (seen.has(key)) continue;
-      seen.add(key);
-    }
-    out.push(word);
-  }
-  return out.join(" ");
-}
 
 function clipAtWord(title: string, limit: number): string {
   if (title.length <= limit) return title;
@@ -34,8 +19,13 @@ function clipAtWord(title: string, limit: number): string {
   return (lastSpace > limit * 0.6 ? cut.slice(0, lastSpace) : cut).trim();
 }
 
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Whole-word containment — a bare substring check made every one-letter size a
+// false positive ("L" is inside almost any word) and missed short colors
+// hiding inside longer words ("Tan" in "Titanium").
 function containsToken(title: string, token: string): boolean {
-  return title.toLowerCase().includes(token.toLowerCase());
+  return new RegExp(`(^|[^\\w])${escapeRe(token)}([^\\w]|$)`, "i").test(title);
 }
 
 // Candidate identifiers buyers search by, in append-priority order.
@@ -58,10 +48,11 @@ function missingTokens(listing: ListingResult, title: string): string[] {
 }
 
 export function optimizeTitle(listing: ListingResult): string {
-  let title = dedupeWords(String(listing.title || "").replace(/\s+/g, " ").trim());
+  let title = String(listing.title || "").replace(/\s+/g, " ").trim();
   for (const token of missingTokens(listing, title)) {
-    if (title.length + 1 + token.length > EBAY_TITLE_LIMIT) continue;
-    title = `${title} ${token}`;
+    const candidate = title ? `${title} ${token}` : token;
+    if (candidate.length > EBAY_TITLE_LIMIT) continue;
+    title = candidate;
   }
   return clipAtWord(title, EBAY_TITLE_LIMIT);
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -57,6 +57,20 @@ export type ItemStatus = "idle" | "writing" | "done" | "error";
 
 export type PostStatus = "idle" | "posting" | "posted" | "error";
 
+// Market price check from active eBay comps (see lib/ebay/comps.ts). Advisory:
+// shown beside the AI's estimate so the seller prices with real data in view.
+export interface CompsSummary {
+  ok: boolean;
+  query: string;
+  count: number;
+  median?: number;
+  trimmedMean?: number;
+  low?: number;
+  high?: number;
+  confidence: number;
+  basis: string;
+}
+
 export interface ItemGroup {
   id: string;
   sku: string; // bin reference, e.g. "K75-A"
@@ -65,8 +79,12 @@ export interface ItemGroup {
   listing?: ListingResult;
   status: ItemStatus;
   error?: string;
+  // Market price check (fetched right after the listing is written)
+  comps?: CompsSummary;
   // eBay posting state (Phase 2)
   postStatus?: PostStatus;
   listingId?: string;
   postError?: string;
+  // Non-fatal quality warnings from the last publish (e.g. schema unavailable)
+  postWarnings?: string[];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "@types/node": "^22.13.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -50,10 +51,33 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -574,6 +598,32 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.19",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz",
@@ -720,6 +770,305 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -728,6 +1077,42 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.21",
@@ -759,6 +1144,129 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -779,10 +1287,27 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/csstype": {
@@ -796,10 +1321,70 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/json-schema-to-ts": {
@@ -813,6 +1398,289 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/nanoid": {
@@ -885,11 +1753,45 @@
         }
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.15",
@@ -938,6 +1840,40 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/scheduler": {
@@ -1004,6 +1940,13 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1012,6 +1955,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -1034,6 +1991,50 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-algebra": {
@@ -1068,6 +2069,191 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.69.0",
@@ -20,7 +21,8 @@
     "@types/node": "^22.13.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.10"
   },
   "overrides": {
     "postcss": "^8.5.10"

--- a/tests/aspects.test.ts
+++ b/tests/aspects.test.ts
@@ -40,12 +40,20 @@ describe("isPlaceholderValue", () => {
     expect(isPlaceholderValue(v)).toBe(true);
   });
 
-  test.each(["Cotton", "Ralph Lauren", "Sterling Silver", "No Hood", "Multicolor", "Nylon blend"])(
-    "keeps real value %j",
-    (v) => {
-      expect(isPlaceholderValue(v)).toBe(false);
-    }
-  );
+  test.each([
+    "Cotton",
+    "Ralph Lauren",
+    "Sterling Silver",
+    "No Hood",
+    "Multicolor",
+    "Nylon blend",
+    // Real values that a sloppier regex once flagged:
+    "See by Chloé",
+    "Check Print",
+    "Not Rated",
+  ])("keeps real value %j", (v) => {
+    expect(isPlaceholderValue(v)).toBe(false);
+  });
 });
 
 describe("cleanAspectValue", () => {
@@ -85,6 +93,12 @@ describe("splitAspectValues", () => {
   test("drops placeholder parts", () => {
     expect(splitAspectValues("Unknown")).toEqual([]);
   });
+  test.each(["AC/DC", "H&M", "Texas A&M", "9 1/2", "S/M"])(
+    "never shreds names/sizes with short fragments: %j stays whole",
+    (v) => {
+      expect(splitAspectValues(v)).toEqual([v]);
+    }
+  );
 });
 
 describe("enforceCardinality", () => {
@@ -102,6 +116,12 @@ describe("enforceCardinality", () => {
     expect(aspects.Color).toEqual(["Black"]);
     // Unknown to eBay's schema — MULTI can't be proven safe.
     expect(aspects.Mystery).toEqual(["A"]);
+  });
+
+  test("Features stays multi-value even when absent from the schema", () => {
+    const aspects: Record<string, string[]> = { Features: ["Pockets", "Lined"] };
+    enforceCardinality(aspects, []);
+    expect(aspects.Features).toEqual(["Pockets", "Lined"]);
   });
 });
 

--- a/tests/aspects.test.ts
+++ b/tests/aspects.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "vitest";
+import {
+  cleanAspectValue,
+  clipAspectValue,
+  enforceCardinality,
+  isPlaceholderValue,
+  matchAllowed,
+  splitAspectValues,
+  canonicalizeAspectKeys,
+} from "@/lib/ebay/aspects";
+import type { AspectMeta } from "@/lib/ebay/taxonomy";
+
+const meta = (over: Partial<AspectMeta>): AspectMeta => ({
+  name: "X",
+  required: false,
+  usage: "OPTIONAL",
+  mode: "FREE_TEXT",
+  cardinality: "SINGLE",
+  values: [],
+  ...over,
+});
+
+describe("isPlaceholderValue", () => {
+  test.each([
+    "See tag in photos",
+    "See listing photos for measurements",
+    "Unknown",
+    "unknown material",
+    "N/A",
+    "n/a",
+    "Not visible",
+    "not shown",
+    "TBD",
+    "check photos",
+    "-",
+    "???",
+    "",
+    "  ",
+  ])("flags %j as placeholder", (v) => {
+    expect(isPlaceholderValue(v)).toBe(true);
+  });
+
+  test.each(["Cotton", "Ralph Lauren", "Sterling Silver", "No Hood", "Multicolor", "Nylon blend"])(
+    "keeps real value %j",
+    (v) => {
+      expect(isPlaceholderValue(v)).toBe(false);
+    }
+  );
+});
+
+describe("cleanAspectValue", () => {
+  test("empties placeholder phrases", () => {
+    expect(cleanAspectValue("See tag in photos")).toBe("");
+  });
+  test("clips long values at word boundary", () => {
+    const long = "word ".repeat(30).trim();
+    expect(cleanAspectValue(long).length).toBeLessThanOrEqual(65);
+  });
+  test("respects a per-aspect max length", () => {
+    expect(cleanAspectValue("A".repeat(40), 30).length).toBeLessThanOrEqual(30);
+  });
+});
+
+describe("splitAspectValues", () => {
+  test("keeps every part of a compound material", () => {
+    expect(splitAspectValues("Cotton / Polyester")).toEqual(["Cotton", "Polyester"]);
+  });
+  test("splits ampersand colors", () => {
+    expect(splitAspectValues("Black & White")).toEqual(["Black", "White"]);
+  });
+  test("splits comma lists", () => {
+    expect(splitAspectValues("Casual, Travel, Workwear")).toEqual([
+      "Casual",
+      "Travel",
+      "Workwear",
+    ]);
+  });
+  test("splits on ' and ' but not inside words", () => {
+    expect(splitAspectValues("Sandals")).toEqual(["Sandals"]);
+    expect(splitAspectValues("Red and Blue")).toEqual(["Red", "Blue"]);
+  });
+  test("flattens arrays and dedupes case-insensitively", () => {
+    expect(splitAspectValues(["Red", "red", "Blue"])).toEqual(["Red", "Blue"]);
+  });
+  test("drops placeholder parts", () => {
+    expect(splitAspectValues("Unknown")).toEqual([]);
+  });
+});
+
+describe("enforceCardinality", () => {
+  test("MULTI aspects keep several values, SINGLE collapse to first", () => {
+    const aspects: Record<string, string[]> = {
+      Material: ["Cotton", "Polyester"],
+      Color: ["Black", "White"],
+      Mystery: ["A", "B"],
+    };
+    enforceCardinality(aspects, [
+      meta({ name: "Material", cardinality: "MULTI" }),
+      meta({ name: "Color", cardinality: "SINGLE" }),
+    ]);
+    expect(aspects.Material).toEqual(["Cotton", "Polyester"]);
+    expect(aspects.Color).toEqual(["Black"]);
+    // Unknown to eBay's schema — MULTI can't be proven safe.
+    expect(aspects.Mystery).toEqual(["A"]);
+  });
+});
+
+describe("matchAllowed", () => {
+  test("case-insensitive with singular/plural tolerance", () => {
+    expect(matchAllowed("unisex adult", ["Unisex Adults", "Men"])).toBe("Unisex Adults");
+  });
+  test("null when nothing matches", () => {
+    expect(matchAllowed("Purple", ["Red", "Blue"])).toBeNull();
+  });
+});
+
+describe("canonicalizeAspectKeys", () => {
+  test("rejoins compound allowed values that splitting broke apart", () => {
+    const aspects: Record<string, string[]> = { Closure: ["Hook", "Eye"] };
+    canonicalizeAspectKeys(aspects, [
+      meta({ name: "Closure", mode: "SELECTION_ONLY", values: ["Zip", "Hook & Eye"] }),
+    ]);
+    expect(aspects.Closure).toEqual(["Hook & Eye"]);
+  });
+  test("snaps each valid value of a multi-value aspect", () => {
+    const aspects: Record<string, string[]> = { Material: ["cotton", "polyester"] };
+    canonicalizeAspectKeys(aspects, [
+      meta({
+        name: "Material",
+        mode: "SELECTION_ONLY",
+        cardinality: "MULTI",
+        values: ["Cotton", "Polyester", "Wool"],
+      }),
+    ]);
+    expect(aspects.Material).toEqual(["Cotton", "Polyester"]);
+  });
+  test("renames model keys to eBay's exact names", () => {
+    const aspects: Record<string, string[]> = { "sleeve length": ["Long Sleeve"] };
+    canonicalizeAspectKeys(aspects, [meta({ name: "Sleeve Length" })]);
+    expect(aspects["Sleeve Length"]).toEqual(["Long Sleeve"]);
+    expect(aspects["sleeve length"]).toBeUndefined();
+  });
+});

--- a/tests/comps.test.ts
+++ b/tests/comps.test.ts
@@ -41,6 +41,14 @@ describe("filterComps", () => {
     expect(prices).toEqual([40]);
   });
 
+  test("dimension titles are NOT mistaken for lots", () => {
+    const prices = filterComps(
+      [item("Framed Watercolor 16 x 20 Landscape", 45)],
+      "EXCELLENT"
+    );
+    expect(prices).toEqual([45]);
+  });
+
   test("excludes wrong-condition comps when condition ids are present", () => {
     const prices = filterComps(
       [item("Sweater", 40, "3000"), item("Sweater NWT", 90, "1000")],

--- a/tests/comps.test.ts
+++ b/tests/comps.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "vitest";
+import { buildCompQuery, compStats, filterComps } from "@/lib/ebay/comps";
+import type { ListingResult } from "@/lib/types";
+
+const listing = (over: Partial<ListingResult>): ListingResult => ({
+  title: "Ralph Lauren Wool Sweater Blue Men's L",
+  description: "",
+  ...over,
+});
+
+describe("buildCompQuery", () => {
+  test("prefers brand + item type", () => {
+    expect(
+      buildCompQuery(listing({ brand: "Ralph Lauren", item_type: "Cable Knit Sweater" }))
+    ).toBe("Ralph Lauren Cable Knit Sweater");
+  });
+  test("ignores No Brand and falls back to the first title words", () => {
+    expect(buildCompQuery(listing({ brand: "No Brand" }))).toBe(
+      "Ralph Lauren Wool Sweater Blue Men's"
+    );
+  });
+});
+
+describe("filterComps", () => {
+  const item = (title: string, price: number, conditionId?: string) => ({
+    title,
+    price: { value: String(price), currency: "USD" },
+    conditionId,
+  });
+
+  test("excludes lots, parts, and reproductions", () => {
+    const prices = filterComps(
+      [
+        item("Ralph Lauren Sweater", 40),
+        item("Lot of 5 Ralph Lauren Sweaters", 120),
+        item("Ralph Lauren Sweater for parts", 5),
+        item("Reproduction Ralph Lauren style Sweater", 15),
+      ],
+      "EXCELLENT"
+    );
+    expect(prices).toEqual([40]);
+  });
+
+  test("excludes wrong-condition comps when condition ids are present", () => {
+    const prices = filterComps(
+      [item("Sweater", 40, "3000"), item("Sweater NWT", 90, "1000")],
+      "EXCELLENT"
+    );
+    expect(prices).toEqual([40]);
+  });
+
+  test("keeps new comps for new items", () => {
+    const prices = filterComps(
+      [item("Sweater", 40, "3000"), item("Sweater NWT", 90, "1000")],
+      "NEW_WITH_TAGS"
+    );
+    expect(prices).toEqual([90]);
+  });
+});
+
+describe("compStats", () => {
+  test("empty prices → zero confidence and no median", () => {
+    const s = compStats([]);
+    expect(s.count).toBe(0);
+    expect(s.confidence).toBe(0);
+    expect(s.median).toBeUndefined();
+  });
+
+  test("computes a sane median and band", () => {
+    const s = compStats([48, 52, 55, 60, 62, 64, 70, 74, 80, 85, 90, 95]);
+    expect(s.count).toBe(12);
+    expect(s.median).toBeGreaterThan(60);
+    expect(s.median).toBeLessThan(70);
+    expect(s.low).toBeLessThan(s.median!);
+    expect(s.high).toBeGreaterThan(s.median!);
+    expect(s.confidence).toBeGreaterThan(0.5);
+  });
+
+  test("wildly dispersed comps lower confidence", () => {
+    const tight = compStats([50, 52, 54, 55, 56, 58, 60, 61, 62, 63, 64, 65]);
+    const loose = compStats([5, 20, 45, 55, 90, 150, 300, 12, 75, 33, 210, 400]);
+    expect(loose.confidence).toBeLessThan(tight.confidence);
+  });
+});

--- a/tests/identifiers.test.ts
+++ b/tests/identifiers.test.ts
@@ -27,6 +27,11 @@ describe("identifier validation", () => {
     expect(validEan("4006381333932")).toBeNull();
   });
 
+  test("all-zero codes pass the checksum but are rejected anyway", () => {
+    expect(validUpc("000000000000")).toBeNull();
+    expect(validEan("0000000000000")).toBeNull();
+  });
+
   test("accepts ISBN-10 and ISBN-13, tolerating dashes", () => {
     expect(validIsbn("0-306-40615-2")).toBe("0306406152");
     expect(validIsbn("978-0-306-40615-7")).toBe("9780306406157");

--- a/tests/identifiers.test.ts
+++ b/tests/identifiers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vitest";
+import {
+  extractProductIdentifiers,
+  hasCatalogIdentifier,
+  validEan,
+  validIsbn,
+  validMpn,
+  validUpc,
+} from "@/lib/ebay/identifiers";
+import type { ListingResult } from "@/lib/types";
+
+const listing = (specifics: Record<string, string>): ListingResult => ({
+  title: "T",
+  description: "D",
+  item_specifics: specifics,
+});
+
+describe("identifier validation", () => {
+  test("accepts a valid UPC-A and rejects bad check digits", () => {
+    expect(validUpc("036000291452")).toBe("036000291452");
+    expect(validUpc("036000291453")).toBeNull();
+    expect(validUpc("1234")).toBeNull();
+  });
+
+  test("accepts a valid EAN-13", () => {
+    expect(validEan("4006381333931")).toBe("4006381333931");
+    expect(validEan("4006381333932")).toBeNull();
+  });
+
+  test("accepts ISBN-10 and ISBN-13, tolerating dashes", () => {
+    expect(validIsbn("0-306-40615-2")).toBe("0306406152");
+    expect(validIsbn("978-0-306-40615-7")).toBe("9780306406157");
+    expect(validIsbn("0306406153")).toBeNull();
+  });
+
+  test("rejects placeholder and sentence-like MPNs", () => {
+    expect(validMpn("A1428")).toBe("A1428");
+    expect(validMpn("See photos")).toBeNull();
+    expect(validMpn("not visible on the tag anywhere")).toBeNull();
+  });
+});
+
+describe("extractProductIdentifiers", () => {
+  test("pulls validated identifiers from item specifics", () => {
+    const ids = extractProductIdentifiers(
+      listing({ UPC: "036000291452", MPN: "GDC-100", ISBN: "" })
+    );
+    expect(ids).toEqual({ upc: "036000291452", mpn: "GDC-100" });
+    expect(hasCatalogIdentifier(ids)).toBe(true);
+  });
+
+  test("a 13-digit 'UPC' is treated as an EAN, Bookland EAN doubles as ISBN", () => {
+    const ids = extractProductIdentifiers(listing({ UPC: "9780306406157" }));
+    expect(ids.ean).toBe("9780306406157");
+    expect(ids.isbn).toBe("9780306406157");
+  });
+
+  test("invalid identifiers never reach eBay", () => {
+    const ids = extractProductIdentifiers(
+      listing({ UPC: "not visible", ISBN: "12345", MPN: "??" })
+    );
+    expect(ids).toEqual({});
+    expect(hasCatalogIdentifier(ids)).toBe(false);
+  });
+});

--- a/tests/measurements.test.ts
+++ b/tests/measurements.test.ts
@@ -25,6 +25,11 @@ describe("parseMeasurements", () => {
     expect(parseMeasurements("waist 29.5 cm").waist).toBe("29.5 cm");
   });
 
+  test("a range before the unit keeps the right unit", () => {
+    expect(parseMeasurements("waist 70-72 cm").waist).toBe("70 cm");
+    expect(parseMeasurements("inseam approx 29-30 in").inseam).toBe("29 in");
+  });
+
   test("returns nothing for unlabeled numbers or placeholder text", () => {
     expect(parseMeasurements("29 31 42")).toEqual({});
     expect(parseMeasurements("See listing photos for measurements")).toEqual({});

--- a/tests/measurements.test.ts
+++ b/tests/measurements.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { parseMeasurements } from "@/lib/measurements";
+
+describe("parseMeasurements", () => {
+  test("extracts labeled pants measurements — the audit's exact failure case", () => {
+    const m = parseMeasurements("Waist 32 in, rise 11 in, inseam 29 in");
+    expect(m.inseam).toBe("29 in");
+    expect(m.waist).toBe("32 in");
+    expect(m.rise).toBe("11 in");
+  });
+
+  test("handles colon and inch-mark formats", () => {
+    expect(parseMeasurements('Inseam: 29"').inseam).toBe("29 in");
+    expect(parseMeasurements("inseam - 30 inches").inseam).toBe("30 in");
+  });
+
+  test("understands pit-to-pit as chest", () => {
+    expect(parseMeasurements("Pit to pit 21 in, length 27 in")).toMatchObject({
+      chest: "21 in",
+      length: "27 in",
+    });
+  });
+
+  test("keeps decimals and cm units", () => {
+    expect(parseMeasurements("waist 29.5 cm").waist).toBe("29.5 cm");
+  });
+
+  test("returns nothing for unlabeled numbers or placeholder text", () => {
+    expect(parseMeasurements("29 31 42")).toEqual({});
+    expect(parseMeasurements("See listing photos for measurements")).toEqual({});
+    expect(parseMeasurements("")).toEqual({});
+    expect(parseMeasurements(undefined)).toEqual({});
+  });
+});

--- a/tests/publish-helpers.test.ts
+++ b/tests/publish-helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { validListingPrice } from "@/lib/ebay/publish";
+import { prioritizeAspects } from "@/lib/ebay/aspectFill";
+import type { AspectMeta } from "@/lib/ebay/taxonomy";
+
+describe("validListingPrice", () => {
+  test("passes real prices through unchanged — no 18% markup", () => {
+    expect(validListingPrice(20)).toBe(20);
+    expect(validListingPrice("49.99")).toBe(49.99);
+    expect(validListingPrice(100)).toBe(100);
+  });
+
+  test("rounds to cents", () => {
+    expect(validListingPrice(19.999)).toBe(20);
+  });
+
+  test("missing/invalid prices block publish instead of becoming $35.39", () => {
+    expect(validListingPrice(undefined)).toBeNull();
+    expect(validListingPrice(0)).toBeNull();
+    expect(validListingPrice(-5)).toBeNull();
+    expect(validListingPrice("")).toBeNull();
+    expect(validListingPrice("abc")).toBeNull();
+  });
+});
+
+describe("prioritizeAspects", () => {
+  const meta = (name: string, usage: AspectMeta["usage"]): AspectMeta => ({
+    name,
+    required: usage === "REQUIRED",
+    usage,
+    mode: "FREE_TEXT",
+    cardinality: "SINGLE",
+    values: [],
+  });
+
+  test("required aspects come first, then recommended, then optional", () => {
+    const sorted = prioritizeAspects([
+      meta("Opt1", "OPTIONAL"),
+      meta("Rec1", "RECOMMENDED"),
+      meta("Req1", "REQUIRED"),
+      meta("Opt2", "OPTIONAL"),
+      meta("Rec2", "RECOMMENDED"),
+    ]);
+    expect(sorted.map((a) => a.usage)).toEqual([
+      "REQUIRED",
+      "RECOMMENDED",
+      "RECOMMENDED",
+      "OPTIONAL",
+      "OPTIONAL",
+    ]);
+    // Stable within a tier.
+    expect(sorted.map((a) => a.name)).toEqual(["Req1", "Rec1", "Rec2", "Opt1", "Opt2"]);
+  });
+});

--- a/tests/titleOptimizer.test.ts
+++ b/tests/titleOptimizer.test.ts
@@ -5,15 +5,40 @@ import type { ListingResult } from "@/lib/types";
 const base: ListingResult = { title: "", description: "" };
 
 describe("optimizeTitle", () => {
-  test("removes exact duplicate words", () => {
-    expect(optimizeTitle({ ...base, title: "Nike Nike Dri-Fit Running Running Top" })).toBe(
-      "Nike Dri-Fit Running Top"
+  test("NEVER removes words — repeated names are legitimate", () => {
+    expect(optimizeTitle({ ...base, title: "BOSS Hugo Boss Wool Blazer" })).toBe(
+      "BOSS Hugo Boss Wool Blazer"
+    );
+    expect(optimizeTitle({ ...base, title: "Duran Duran Rio Vinyl LP" })).toBe(
+      "Duran Duran Rio Vinyl LP"
+    );
+    expect(optimizeTitle({ ...base, title: "Mickey & Minnie Salt & Pepper Shakers" })).toBe(
+      "Mickey & Minnie Salt & Pepper Shakers"
     );
   });
 
   test("appends a missing brand when there's room", () => {
     const t = optimizeTitle({ ...base, title: "Blue Wool Sweater", brand: "Pendleton" });
     expect(t).toContain("Pendleton");
+  });
+
+  test("one-letter size appends despite the letter appearing inside words", () => {
+    const t = optimizeTitle({
+      ...base,
+      title: "Blue Wool Sweater", // contains "l" inside words
+      category: "womens_sweater",
+      size: "L",
+    });
+    expect(t).toBe("Blue Wool Sweater Sz L");
+  });
+
+  test("short color hiding inside a longer word still appends", () => {
+    const t = optimizeTitle({ ...base, title: "Titanium Ring", color: ["Tan"] });
+    expect(t).toBe("Titanium Ring Tan");
+  });
+
+  test("empty model title never yields a leading space", () => {
+    expect(optimizeTitle({ ...base, title: "", brand: "Nike" })).toBe("Nike");
   });
 
   test("appends size for apparel with the Sz prefix", () => {

--- a/tests/titleOptimizer.test.ts
+++ b/tests/titleOptimizer.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { optimizeTitle, EBAY_TITLE_LIMIT } from "@/lib/titleOptimizer";
+import type { ListingResult } from "@/lib/types";
+
+const base: ListingResult = { title: "", description: "" };
+
+describe("optimizeTitle", () => {
+  test("removes exact duplicate words", () => {
+    expect(optimizeTitle({ ...base, title: "Nike Nike Dri-Fit Running Running Top" })).toBe(
+      "Nike Dri-Fit Running Top"
+    );
+  });
+
+  test("appends a missing brand when there's room", () => {
+    const t = optimizeTitle({ ...base, title: "Blue Wool Sweater", brand: "Pendleton" });
+    expect(t).toContain("Pendleton");
+  });
+
+  test("appends size for apparel with the Sz prefix", () => {
+    const t = optimizeTitle({
+      ...base,
+      title: "Levi's 501 Jeans",
+      category: "mens_jeans",
+      size: "32x34",
+    });
+    expect(t).toContain("32x34");
+  });
+
+  test("never exceeds eBay's 80-character cap", () => {
+    const t = optimizeTitle({
+      ...base,
+      title: "Very Detailed Vintage Collectible Item Name That Goes On".repeat(3),
+      brand: "SomeBrandName",
+    });
+    expect(t.length).toBeLessThanOrEqual(EBAY_TITLE_LIMIT);
+  });
+
+  test("skips No Brand / duplicate identifiers", () => {
+    const t = optimizeTitle({
+      ...base,
+      title: "Coach Tan Leather Tote",
+      brand: "No Brand",
+      color: ["Tan"],
+    });
+    expect(t).toBe("Coach Tan Leather Tote");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+  test: {
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Implements the recommendations from the full code audit (Phases 1 and 2, plus most of Phase 3). Every audit claim was first verified against the code — all of them checked out.

## Pricing (audit #1 — critical)
- **The 18% hidden markup and the $29.99 default are gone.** The price you review on the card is the price that publishes. A missing/zero price now blocks the publish with a clear error (and the card shows "⚠️ needs a price") instead of silently listing at $35.39.
- **New market check**: after each listing is written, the app searches active eBay comps via the Browse API (`lib/ebay/comps.ts`, `/api/ebay/comps`), filters out lots/parts/repros/wrong-condition listings, and shows count + price band + one-click "use median" under the Price field. Uses the existing app token; results cached 10 min. (Sold-comp data requires eBay's gated Marketplace Insights API, so active asking prices are used as a sanity band and labeled as such.)

## Item specifics (audit #2, #3, #4, #5 — the architectural fix)
- **The category-aware aspect pass now sees the original photos.** At publish time the photos are already in the request, so the fill call sends them together with eBay's exact aspect schema — the model that knows the schema can now also see the item. This was the audit's core finding.
- **25-aspect cap removed**; aspects are prioritized required → recommended → optional (cap 40, logged when trimmed).
- **Multi-value aspects survive**: cardinality/usage/maxLength are read from the Taxonomy API; "Cotton/Polyester" keeps both materials, "Black & White" keeps both colors, while "AC/DC", "H&M", "9 1/2" are never shredded and compound allowed values ("Hook & Eye") are re-joined.
- **Placeholder text can never become a specific**: "See tag in photos" etc. is filtered at every entry point (and the prompts no longer ask for it), while real values like "See by Chloé" and "Check Print" survive.

## Measurements (audit #6)
Structured parsing (`lib/measurements.ts`): Inseam/Waist/Rise are filled only from explicitly labeled measurements. `Inseam = "Waist 32 in, rise 11 in, ins"` can't happen anymore.

## Categories (audit #8)
Fallbacks after a category rejection are now eBay's own runner-up suggestions for *this* item. When none work, the publish stops with an actionable error instead of landing the item in Dolls/Puzzles/Plush.

## Catalog matching (audit #9)
Validated UPC/EAN/ISBN/MPN (check-digit verified, all-zero rejected) go into the Inventory product fields, and `includeCatalogProductDetails` turns on for media/hard-goods items that carry a strong identifier.

## Also
- Package weight/size defaults profiled by item class (coats, boots, handbags, media, art, fragile 3D…) instead of one 1-lb envelope for everything; `EBAY_DEFAULT_PACKAGE_*` env vars still override.
- Taxonomy failures now surface as warnings on the posted card; `EBAY_STRICT_QUALITY=1` turns them into hard stops.
- Deterministic title cleanup at analyze time (appends missing brand/size/color when room under 80 chars — never removes words, so "BOSS Hugo Boss" and "Duran Duran" are safe). The reviewed title is the published title.
- **First test suite**: vitest + 79 unit tests over the new pure modules (`npm test`).

## Review process
After implementation, a 4-lens adversarial review (correctness / regressions / edge cases / security-cost) with per-finding verification produced 28 findings; the 22 confirmed ones are all fixed in the second commit, each with a regression test.

## Verification
- `npm test` — 79/79 passing
- `npm run build` — green
- `/api/ebay/comps` exercised live against the production Browse API (real comps returned for sweater + framed-art queries)
- Publish flow not exercised end-to-end (needs a live posting); recovery paths preserved and unit-covered where pure

## Not implemented (from the audit, deliberately)
- Full v2 stage reorder (category chosen before first analysis) — the vision + real-schema pass at publish time achieves the same data quality without restructuring the client flow
- Sold-comp research — Marketplace Insights API requires eBay approval
- Per-field provenance/confidence records and the 100-item gold fixture dataset — worthwhile later, larger schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)