### PR TITLE
fix: never re-bill unchanged listings after a SKU fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,18 @@ You can get your own copy running without ever opening a terminal.
 
    [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/ashnicholes-droid/hahm-ebay-lister)
 
-   When Vercel asks for **Environment Variables**, set **both** of these:
+   Set **both** of these environment variables. Vercel sometimes asks for them
+   during the deploy — but **its current flow often doesn't ask at all**. If you
+   weren't prompted, deploy first, then add them under **your project →
+   Settings → Environment Variables** and hit **Redeploy** (Deployments → ⋯ →
+   Redeploy):
    - `ANTHROPIC_API_KEY` — your Anthropic key (starts with `sk-ant-`).
    - `APP_SECRET` — any access code you make up (a memorable phrase works). A
      deployed app **won't run without this**: it stops strangers from spending
      your Anthropic credits, and every AI action returns an error until it's set.
 
-   (You can add the eBay variables later.) Click **Deploy** and wait about a
-   minute — you'll get a web address like `https://your-app.vercel.app`.
+   (You can add the eBay variables later.) After deploying you'll get a web
+   address like `https://your-app.vercel.app`.
 
 **3. Bookmark your app** on your computer and add it to your phone's home
    screen. You can start sorting and writing listings immediately.

--- a/app/ListingCard.tsx
+++ b/app/ListingCard.tsx
@@ -57,6 +57,7 @@ interface ListingCardProps {
   photoById: (id: string) => Photo | undefined;
   ebayConnected: boolean;
   onEdit: (groupId: string, patch: Partial<ListingResult>) => void;
+  onRenameSku: (groupId: string, sku: string) => void;
   onRetry: (groupId: string) => void;
   onPost: (groupId: string) => void;
 }
@@ -66,6 +67,7 @@ export function ListingCard({
   photoById,
   ebayConnected,
   onEdit,
+  onRenameSku,
   onRetry,
   onPost,
 }: ListingCardProps) {
@@ -166,6 +168,21 @@ export function ListingCard({
           </div>
 
           <div className="meta-row">
+            {/* SKU stays editable up until the item is posted, so a SKU fix
+                never requires going back and re-writing listings (issue #30). */}
+            <div className="stat editable">
+              <label className="k" htmlFor={`sku-${group.id}`}>
+                SKU
+              </label>
+              <input
+                id={`sku-${group.id}`}
+                type="text"
+                className="size-input"
+                value={group.sku}
+                disabled={group.postStatus === "posted"}
+                onChange={(e) => onRenameSku(group.id, e.target.value)}
+              />
+            </div>
             <div className={`stat editable${priceMissing ? " needs-attention" : ""}`}>
               <label className="k" htmlFor={`price-${group.id}`}>
                 Price

--- a/app/ListingsView.tsx
+++ b/app/ListingsView.tsx
@@ -13,6 +13,7 @@ interface ListingsViewProps {
   photoById: (id: string) => Photo | undefined;
   ebayConnected: boolean;
   onEdit: (groupId: string, patch: Partial<ListingResult>) => void;
+  onRenameSku: (groupId: string, sku: string) => void;
   onRetry: (groupId: string) => void;
   onPost: (groupId: string) => void;
   onPostAll: () => void;
@@ -24,6 +25,7 @@ export function ListingsView({
   photoById,
   ebayConnected,
   onEdit,
+  onRenameSku,
   onRetry,
   onPost,
   onPostAll,
@@ -83,6 +85,7 @@ export function ListingsView({
             photoById={photoById}
             ebayConnected={ebayConnected}
             onEdit={onEdit}
+            onRenameSku={onRenameSku}
             onRetry={onRetry}
             onPost={onPost}
           />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -277,15 +277,22 @@ export default function Home() {
 
   const movePhoto = (photoId: string, toGroupId: string | "orphans") => {
     setGroups((prev) =>
-      prev.map((g) => ({
-        ...g,
-        photoIds:
+      prev.map((g) => {
+        const nextIds =
           g.id === toGroupId
             ? g.photoIds.includes(photoId)
               ? g.photoIds
               : [...g.photoIds, photoId]
-            : g.photoIds.filter((id) => id !== photoId),
-      }))
+            : g.photoIds.filter((id) => id !== photoId);
+        // A gained/lost photo invalidates an already-written listing — reset
+        // it so "Write all listings" knows to redo this one (and only this one).
+        const changed = nextIds.length !== g.photoIds.length;
+        return {
+          ...g,
+          photoIds: nextIds,
+          ...(changed && g.status === "done" ? { status: "idle" as const } : {}),
+        };
+      })
     );
     setOrphanIds((prev) => {
       const without = prev.filter((id) => id !== photoId);
@@ -400,9 +407,15 @@ export default function Home() {
   );
 
   const writeAll = async () => {
-    const usable = groups.filter((g) => g.photoIds.length > 0).map((g) => g.id);
-    if (usable.length === 0) return;
+    // Only write listings that don't exist yet. Re-running everything after a
+    // trip back to the review step re-billed the AI for unchanged listings
+    // (issue #30) — groups whose photos changed are reset to "idle" by
+    // movePhoto, so they (and only they) get rewritten here.
+    const usable = groups
+      .filter((g) => g.photoIds.length > 0 && g.status !== "done")
+      .map((g) => g.id);
     setStep("listings");
+    if (usable.length === 0) return;
     await runPool(usable, WRITE_CONCURRENCY, writeGroup);
   };
 
@@ -671,6 +684,7 @@ export default function Home() {
           photoById={photoById}
           ebayConnected={ebayConnected}
           onEdit={editListing}
+          onRenameSku={renameSku}
           onRetry={writeGroup}
           onPost={postGroup}
           onPostAll={postAll}


### PR DESCRIPTION
Fixes #30. Also gives #27 a practical workaround and covers the docs gap from #29.

- **"Write all listings" skips already-written listings.** Going back to review to fix a SKU used to re-run analysis on every group — paying Anthropic again for listings that didn't change.
- **Photo changes invalidate only that listing.** Moving a photo in/out of a written group resets it to idle, so it (and only it) gets rewritten.
- **SKU is editable right on the listing card** until the item is posted — most SKU fixes now need no round trip at all, and #27's "remove the letter suffix" is doable there too.
- **README:** Vercel's current deploy flow often doesn't prompt for env vars; documented the Settings → Redeploy path (#29).

Verified: tsc clean, 79/79 tests, production build green, app renders without console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)