### PR TITLE
fix: eBay <BrandMPN> publish failures

### DIFF
--- a/lib/ebay/identifiers.ts
+++ b/lib/ebay/identifiers.ts
@@ -130,3 +130,15 @@ export function extractProductIdentifiers(listing: ListingResult): ProductIdenti
 export function hasCatalogIdentifier(ids: ProductIdentifiers): boolean {
   return Boolean(ids.upc || ids.ean || ids.isbn);
 }
+
+// A brand value eBay's Brand/MPN pair validation will accept: a real brand
+// name — not a placeholder, not the unbranded markers. eBay rejects an MPN
+// whose brand half is missing (error 25002, tag <BrandMPN>), so the publish
+// pipeline only ships an MPN when this returns something.
+export function realBrand(listing: ListingResult): string {
+  const b = String(listing.brand || "").trim();
+  if (!b || isPlaceholderValue(b) || /^(no\s?brand|unbranded|unknown|generic|n\/?a)$/i.test(b)) {
+    return "";
+  }
+  return b.slice(0, 65);
+}

--- a/lib/ebay/publish.ts
+++ b/lib/ebay/publish.ts
@@ -25,7 +25,7 @@ import {
   enforceCardinality,
 } from "./aspects";
 import { fillRecommendedAspects } from "./aspectFill";
-import { extractProductIdentifiers, hasCatalogIdentifier } from "./identifiers";
+import { extractProductIdentifiers, hasCatalogIdentifier, realBrand } from "./identifiers";
 import { parseMeasurements } from "@/lib/measurements";
 import { APPAREL_CATEGORIES, PANTS_CATEGORIES } from "@/lib/categories";
 import type { ListingResult } from "@/lib/types";
@@ -617,6 +617,34 @@ function addMissingAspects(
   return added;
 }
 
+// eBay's Brand/MPN pair validation (25002, tag <BrandMPN>): fires when an MPN
+// arrives without a brand, when the pair doesn't match a catalog product, or
+// when a category requires the Brand/MPN aspects and one is absent.
+export function isBrandMpnError(r: EbayResp): boolean {
+  return /BrandMPN/i.test(r.text || "");
+}
+
+// Recovery for a rejected Brand/MPN pair: drop the product-level pair and fall
+// back to eBay's own aspect conventions — a Brand (or "Unbranded") plus MPN
+// "Does Not Apply". Both are canonical eBay values, not placeholders.
+export function applyBrandMpnFallback(
+  inventoryItem: { product: { aspects?: Record<string, string[]>; brand?: string; mpn?: string } },
+  aspects: Record<string, string[]>,
+  listing: ListingResult,
+  sku: string
+): void {
+  console.warn(
+    `[ebay/publish] sku=${sku} eBay rejected the Brand/MPN pair (<BrandMPN>) — retrying with aspect-level fallbacks`
+  );
+  delete inventoryItem.product.brand;
+  delete inventoryItem.product.mpn;
+  if (!aspects.Brand?.length) {
+    aspects.Brand = [cleanAspectValue(String(listing.brand || "").trim()) || "Unbranded"];
+  }
+  if (!aspects.MPN?.length) aspects.MPN = ["Does Not Apply"];
+  inventoryItem.product.aspects = aspects;
+}
+
 function updateOfferBody(offer: Record<string, unknown>): Record<string, unknown> {
   const skip = new Set(["sku", "marketplaceId", "format"]);
   return Object.fromEntries(Object.entries(offer).filter(([k]) => !skip.has(k)));
@@ -939,6 +967,7 @@ export async function publishListing(
   // Real product identifiers (validated UPC/EAN/ISBN/MPN) ride along so eBay
   // can catalog-match commodity items; one-off vintage pieces have none.
   const identifiers = extractProductIdentifiers(listing);
+  const brand = realBrand(listing);
   const inventoryItem: any = {
     product: {
       title: String(listing.title || "Untitled").slice(0, 80),
@@ -948,7 +977,10 @@ export async function publishListing(
       ...(identifiers.upc ? { upc: [identifiers.upc] } : {}),
       ...(identifiers.ean ? { ean: [identifiers.ean] } : {}),
       ...(identifiers.isbn ? { isbn: [identifiers.isbn] } : {}),
-      ...(identifiers.mpn ? { mpn: identifiers.mpn } : {}),
+      // eBay validates brand and MPN as a PAIR — an MPN without a brand fails
+      // publish with 25002 "Input data for tag <BrandMPN> is invalid or
+      // missing". Ship both or neither.
+      ...(identifiers.mpn && brand ? { brand, mpn: identifiers.mpn } : {}),
     },
     condition,
     conditionDescription: listing.condition_notes || "",
@@ -974,6 +1006,11 @@ export async function publishListing(
     const missing = extractMissingAspects(r);
     if (missing.length && addMissingAspects(aspects, missing, listing).length) {
       inventoryItem.product.aspects = aspects;
+      r = await putInventory();
+    }
+    // Recovery: rejected Brand/MPN pair (25002 <BrandMPN>).
+    if (![200, 201, 204].includes(r.status) && isBrandMpnError(r)) {
+      applyBrandMpnFallback(inventoryItem, aspects, listing, sku);
       r = await putInventory();
     }
     // Recovery: condition invalid for this category (25021/25059) → step down
@@ -1186,6 +1223,16 @@ async function publishOfferWithRecovery(
   const missing = extractMissingAspects(r);
   if (missing.length && addMissingAspects(ctx.aspects, missing, ctx.listing).length) {
     ctx.inventoryItem.product.aspects = ctx.aspects;
+    await putInventory();
+    r = await doPublish();
+    if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "", warnings };
+    eids = errorIds(r);
+  }
+
+  // Recovery: rejected Brand/MPN pair (25002 <BrandMPN>) — eBay validates the
+  // pair at publish time even when the inventory PUT succeeded.
+  if (isBrandMpnError(r)) {
+    applyBrandMpnFallback(ctx.inventoryItem, ctx.aspects, ctx.listing, sku);
     await putInventory();
     r = await doPublish();
     if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "", warnings };

--- a/tests/brand-mpn.test.ts
+++ b/tests/brand-mpn.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import { applyBrandMpnFallback, isBrandMpnError } from "@/lib/ebay/publish";
+import type { ListingResult } from "@/lib/types";
+
+const ebayResp = (text: string) => ({ ok: false, status: 400, json: null, text });
+
+describe("isBrandMpnError", () => {
+  test("matches eBay's <BrandMPN> publish rejection", () => {
+    expect(
+      isBrandMpnError(
+        ebayResp(
+          '{"errors":[{"errorId":25002,"message":"A user error has occurred. Input data for tag <BrandMPN> is invalid or missing. Please check API documentation."}]}'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test("ignores unrelated 25002 errors", () => {
+    expect(
+      isBrandMpnError(ebayResp('{"errors":[{"errorId":25002,"message":"The ISBN field is missing."}]}'))
+    ).toBe(false);
+  });
+});
+
+describe("applyBrandMpnFallback", () => {
+  const listing: ListingResult = { title: "t", description: "d", brand: "Carhartt" };
+
+  test("drops the product-level pair and fills the aspect conventions", () => {
+    const aspects: Record<string, string[]> = {};
+    const item = { product: { brand: "Carhartt", mpn: "K87-BLK", aspects } };
+    applyBrandMpnFallback(item, aspects, listing, "TEST-A");
+    expect(item.product.brand).toBeUndefined();
+    expect(item.product.mpn).toBeUndefined();
+    expect(aspects.Brand).toEqual(["Carhartt"]);
+    expect(aspects.MPN).toEqual(["Does Not Apply"]);
+    expect(item.product.aspects).toBe(aspects);
+  });
+
+  test("never overwrites existing Brand/MPN aspects", () => {
+    const aspects: Record<string, string[]> = { Brand: ["Levi's"], MPN: ["501-0193"] };
+    const item = { product: { mpn: "501-0193", aspects } };
+    applyBrandMpnFallback(item, aspects, listing, "TEST-B");
+    expect(aspects.Brand).toEqual(["Levi's"]);
+    expect(aspects.MPN).toEqual(["501-0193"]);
+  });
+
+  test("falls back to Unbranded when the listing has no usable brand", () => {
+    const aspects: Record<string, string[]> = {};
+    const item = { product: { aspects } };
+    applyBrandMpnFallback(item, aspects, { title: "t", description: "d" }, "TEST-C");
+    expect(aspects.Brand).toEqual(["Unbranded"]);
+  });
+});

--- a/tests/identifiers.test.ts
+++ b/tests/identifiers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   extractProductIdentifiers,
   hasCatalogIdentifier,
+  realBrand,
   validEan,
   validIsbn,
   validMpn,
@@ -67,4 +68,19 @@ describe("extractProductIdentifiers", () => {
     expect(ids).toEqual({});
     expect(hasCatalogIdentifier(ids)).toBe(false);
   });
+});
+
+describe("realBrand", () => {
+  test("returns a genuine brand", () => {
+    expect(realBrand({ title: "t", description: "d", brand: "Ralph Lauren" })).toBe(
+      "Ralph Lauren"
+    );
+  });
+
+  test.each(["No Brand", "Unbranded", "Unknown", "generic", "n/a", "", undefined])(
+    "returns empty for %j — an MPN must never ship without a real brand",
+    (b) => {
+      expect(realBrand({ title: "t", description: "d", brand: b as string })).toBe("");
+    }
+  );
 });


### PR DESCRIPTION
Fixes the "Publish failed (eBay error 25002): Input data for tag <BrandMPN> is invalid or missing" regression from #32.

**Cause:** #32 started sending `product.mpn` whenever the analysis found a part/style number, but never sent `product.brand` — eBay validates brand+MPN as a pair. Since the analysis prompt maps clothing style numbers into MPN, ordinary apparel could trip it.

**Fix:**
- `product.mpn` ships only alongside a real `product.brand` (placeholder and Unbranded/No Brand markers don't count)
- New recovery in both the inventory-create and publish stages: on a `<BrandMPN>` rejection, strip the product-level pair, fall back to eBay's aspect conventions (Brand or "Unbranded", MPN "Does Not Apply"), retry once — also covers categories that require the Brand/MPN *aspects*

**Verification:** tsc clean, 92/92 tests (13 new), production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)