### PR TITLE
fix: 413 on photo-heavy posts — batch photo uploads before publish

### DIFF
--- a/app/api/ebay/publish/route.ts
+++ b/app/api/ebay/publish/route.ts
@@ -21,7 +21,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ success: false, error: "Invalid request." }, { status: 400 });
   }
 
-  if (!body.sku || !body.listing || !Array.isArray(body.images) || body.images.length === 0) {
+  const hasImages = Array.isArray(body.images) && body.images.length > 0;
+  const hasImageUrls = Array.isArray(body.imageUrls) && body.imageUrls.length > 0;
+  if (!body.sku || !body.listing || (!hasImages && !hasImageUrls)) {
     return NextResponse.json(
       { success: false, error: "Missing SKU, listing, or photos." },
       { status: 400 }

--- a/app/api/ebay/upload-photos/route.ts
+++ b/app/api/ebay/upload-photos/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { EBAY_COOKIE, accessTokenFromCookie } from "@/lib/ebay/session";
+import { guardApiRequest } from "@/lib/api-guard";
+import { uploadPhotos } from "@/lib/ebay/publish";
+
+// Uploads ONE small batch of photos to eBay Picture Services and returns the
+// hosted URLs. The client splits a listing's photos into batches sized well
+// under Vercel's 4.5 MB body limit (lib/uploadBatches.ts), then publishes with
+// the URLs — so the posting flow can never 413 no matter how photo-heavy an
+// item is.
+
+// A batch is ≤4 photos uploaded with internal concurrency; 120s is generous
+// headroom for eBay Picture Services on a slow day.
+export const maxDuration = 120;
+
+// Hard cap on photos per request — the client sends at most 4 (MAX_BATCH_PHOTOS);
+// anything larger is a misbehaving caller, not our flow.
+const MAX_PHOTOS_PER_REQUEST = 6;
+
+interface UploadBody {
+  sku?: string;
+  images?: { mediaType?: string; data?: string }[];
+  // How many photos of this listing were uploaded in earlier batches — keeps
+  // eBay picture names numbered continuously across batches.
+  startIndex?: number;
+}
+
+export async function POST(req: NextRequest) {
+  // Check access + rate limit BEFORE parsing the (potentially large) body.
+  const denied = guardApiRequest(req);
+  if (denied) return denied;
+
+  let body: UploadBody;
+  try {
+    body = (await req.json()) as UploadBody;
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid request." }, { status: 400 });
+  }
+
+  const sku = String(body.sku || "").trim();
+  const images = (Array.isArray(body.images) ? body.images : []).filter(
+    (i): i is { mediaType: string; data: string } =>
+      Boolean(i && typeof i.mediaType === "string" && typeof i.data === "string" && i.data)
+  );
+  if (!sku || images.length === 0) {
+    return NextResponse.json(
+      { ok: false, error: "Missing SKU or photos." },
+      { status: 400 }
+    );
+  }
+  if (images.length > MAX_PHOTOS_PER_REQUEST) {
+    return NextResponse.json(
+      { ok: false, error: `Too many photos in one batch (max ${MAX_PHOTOS_PER_REQUEST}).` },
+      { status: 400 }
+    );
+  }
+
+  let accessToken: string | null;
+  try {
+    accessToken = await accessTokenFromCookie(req.cookies.get(EBAY_COOKIE)?.value);
+  } catch (e) {
+    return NextResponse.json({ ok: false, error: (e as Error).message }, { status: 500 });
+  }
+  if (!accessToken) {
+    return NextResponse.json(
+      { ok: false, error: "eBay isn't connected. Connect your account and try again." },
+      { status: 401 }
+    );
+  }
+
+  const startIndex =
+    Number.isInteger(body.startIndex) && (body.startIndex as number) > 0
+      ? (body.startIndex as number)
+      : 0;
+
+  try {
+    const urls = await uploadPhotos(accessToken, images, sku, startIndex);
+    // Partial success is reported, not hidden — the client warns the seller
+    // when a listing goes up with fewer photos than were selected.
+    return NextResponse.json({ ok: true, urls, failed: images.length - urls.length });
+  } catch (e) {
+    console.error(`[ebay/upload-photos] unhandled error sku=${sku}:`, e);
+    return NextResponse.json({ ok: false, error: (e as Error).message }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { apiPost } from "@/lib/api-client";
 import { getAnalysisModel, getSortModel } from "@/lib/model-preferences";
 import { resizeImage } from "@/lib/resize";
 import { buildSku } from "@/lib/sku";
+import { chunkImagesForUpload } from "@/lib/uploadBatches";
 import { EbayConnect } from "./EbayConnect";
 import { ModelSelector } from "./ModelSelector";
 import { ReviewBoard } from "./ReviewBoard";
@@ -25,9 +26,13 @@ type Step = "upload" | "review" | "listings";
 const MAX_PHOTOS = 300;
 const SORT_CHUNK = 100;
 const WRITE_CONCURRENCY = 3;
-// eBay accepts at most 12 photos per listing; sending more just bloats the
-// publish request toward Vercel's body limit.
+// eBay accepts at most 12 photos per listing. They ship to eBay in small
+// batches (lib/uploadBatches.ts) before publish, so no single request ever
+// nears Vercel's 4.5 MB body limit.
 const MAX_PUBLISH_PHOTOS = 12;
+// HTTP statuses worth waiting out and retrying: rate limits and transient
+// platform errors.
+const TRANSIENT_STATUSES = new Set([429, 502, 503, 504]);
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -39,15 +44,20 @@ function newId(): string {
 
 // Parse a fetch response as JSON, but turn non-JSON error bodies (e.g. a 413
 // "Request Entity Too Large" plain-text page) into a friendly message instead
-// of a cryptic "Unexpected token" error.
-async function readJson(res: Response): Promise<any> {
+// of a cryptic "Unexpected token" error. Callers pass a hint that fits their
+// step — "sort fewer photos" advice on a posting error sent sellers down the
+// wrong path.
+async function readJson(
+  res: Response,
+  tooLargeHint = "Try again with fewer or smaller photos."
+): Promise<any> {
   const text = await res.text();
   try {
     return JSON.parse(text);
   } catch {
     if (res.status === 413) {
       throw new Error(
-        "That was too much photo data to send at once. Try sorting fewer photos per batch."
+        `That was too much photo data to send at once. ${tooLargeHint}`
       );
     }
     throw new Error(
@@ -184,7 +194,7 @@ export default function Home() {
           })),
           sortModel: getSortModel() ?? undefined,
         });
-        const data = (await readJson(res)) as SortResponse;
+        const data = (await readJson(res, "Try sorting fewer photos per batch.")) as SortResponse;
         if (!data.ok || !data.groups) {
           throw new Error(data.error || "Could not sort the photos.");
         }
@@ -443,6 +453,42 @@ export default function Home() {
         )
       );
       try {
+        // 1. Ship the photos to eBay first, in batches small enough that no
+        // single request can hit Vercel's 4.5 MB body limit — the old
+        // all-in-one publish request 413-failed on photo-heavy listings.
+        const imageUrls: string[] = [];
+        let uploadedCount = 0;
+        for (const batch of chunkImagesForUpload(images)) {
+          for (let attempt = 0; ; attempt++) {
+            const res = await apiPost("/api/ebay/upload-photos", {
+              sku: group.sku,
+              images: batch,
+              startIndex: uploadedCount,
+            });
+            if (attempt < 2 && TRANSIENT_STATUSES.has(res.status)) {
+              await sleep(res.status === 429 ? 65_000 : 8_000);
+              continue;
+            }
+            const d = (await readJson(res)) as { ok?: boolean; error?: string; urls?: string[] };
+            if (!d.ok) throw new Error(d.error || "Could not upload photos to eBay.");
+            imageUrls.push(...(Array.isArray(d.urls) ? d.urls : []));
+            break;
+          }
+          uploadedCount += batch.length;
+        }
+        if (imageUrls.length === 0) {
+          throw new Error("Could not upload any photos to eBay.");
+        }
+        // Partial upload failures don't block the listing, but they're loud —
+        // a listing quietly missing photos sells worse and looks like a bug.
+        const uploadWarnings =
+          imageUrls.length < images.length
+            ? [
+                `${images.length - imageUrls.length} photo(s) failed to upload to eBay — the listing was posted with ${imageUrls.length}.`,
+              ]
+            : [];
+
+        // 2. Publish with the eBay-hosted URLs (a few KB instead of megabytes).
         let data: {
           success: boolean;
           listingId?: string;
@@ -455,14 +501,11 @@ export default function Home() {
           const res = await apiPost("/api/ebay/publish", {
             sku: group.sku,
             listing: group.listing,
-            images,
+            imageUrls,
           });
           // Wait out rate limits / transient platform errors instead of dying
           // mid-batch with "try again later".
-          if (
-            attempt < 2 &&
-            (res.status === 429 || res.status === 502 || res.status === 503 || res.status === 504)
-          ) {
+          if (attempt < 2 && TRANSIENT_STATUSES.has(res.status)) {
             hadTransientRetry = true;
             await sleep(res.status === 429 ? 65_000 : 8_000);
             continue;
@@ -476,6 +519,7 @@ export default function Home() {
           data = { success: true, listingId: data.listingId };
         }
         if (!data?.success) throw new Error(data?.error || "eBay rejected the listing.");
+        const allWarnings = [...uploadWarnings, ...(data.warnings ?? [])];
         setGroups((prev) =>
           prev.map((g) =>
             g.id === groupId
@@ -483,7 +527,7 @@ export default function Home() {
                   ...g,
                   postStatus: "posted",
                   listingId: data!.listingId,
-                  postWarnings: data!.warnings,
+                  postWarnings: allWarnings.length ? allWarnings : undefined,
                 }
               : g
           )

--- a/lib/ebay/aspectFill.ts
+++ b/lib/ebay/aspectFill.ts
@@ -14,7 +14,7 @@
 // Strictly best-effort: any failure leaves the aspects untouched.
 
 import { getClient, parseModelJson } from "@/lib/anthropic";
-import { toImageBlock, type WireImage } from "@/lib/images";
+import { toImageBlock, urlImageBlock, type WireImage } from "@/lib/images";
 import type { ListingResult } from "@/lib/types";
 import type { AspectMeta } from "./taxonomy";
 import { cleanAspectValue, matchAllowed, splitAspectValues, MAX_MULTI_VALUES } from "./aspects";
@@ -54,7 +54,11 @@ export async function fillRecommendedAspects(
   aspects: Record<string, string[]>,
   meta: AspectMeta[],
   sku: string,
-  images: WireImage[] = []
+  images: WireImage[] = [],
+  // When the client pre-uploaded photos to eBay (batched to dodge Vercel's
+  // body limit), the publish request has no base64 in hand — the vision pass
+  // reads the eBay-hosted URLs instead, so photo grounding survives.
+  imageUrls: string[] = []
 ): Promise<void> {
   const have = new Set(Object.keys(aspects).map((k) => k.toLowerCase()));
   const candidates = prioritizeAspects(
@@ -91,10 +95,11 @@ export async function fillRecommendedAspects(
     description: clip(listing.description, 900),
   };
 
-  const imageBlocks = images
-    .slice(0, MAX_FILL_IMAGES)
-    .map(toImageBlock)
-    .filter((b): b is NonNullable<ReturnType<typeof toImageBlock>> => Boolean(b));
+  const imageBlocks = (
+    images.length
+      ? images.slice(0, MAX_FILL_IMAGES).map(toImageBlock)
+      : imageUrls.slice(0, MAX_FILL_IMAGES).map(urlImageBlock)
+  ).filter((b): b is NonNullable<ReturnType<typeof toImageBlock>> => Boolean(b));
 
   const prompt = `You are completing eBay item specifics for a listing that is about to publish.
 ${imageBlocks.length ? "The photos above show the actual item. Inspect every photo again — tags, labels, stamps, close-ups — for evidence." : ""}

--- a/lib/ebay/publish.ts
+++ b/lib/ebay/publish.ts
@@ -803,7 +803,31 @@ async function fetchOrCreateLocation(accessToken: string): Promise<string> {
 export interface PublishInput {
   sku: string;
   listing: ListingResult;
-  images: { mediaType: string; data: string }[];
+  // Base64 photos to upload to eBay in this request (legacy single-request
+  // flow — the whole payload counts against Vercel's 4.5 MB body limit).
+  images?: { mediaType: string; data: string }[];
+  // eBay-hosted photo URLs from /api/ebay/upload-photos. The preferred flow:
+  // photos ship in small batches beforehand, so the publish body stays tiny.
+  imageUrls?: string[];
+}
+
+// Only accept photo URLs that eBay Picture Services itself minted — anything
+// else in `imageUrls` is a malformed or tampered request, not our upload flow.
+export function sanitizeEbayImageUrls(urls: unknown): string[] {
+  if (!Array.isArray(urls)) return [];
+  const out: string[] = [];
+  for (const raw of urls) {
+    if (typeof raw !== "string") continue;
+    try {
+      const u = new URL(raw);
+      const host = u.hostname.toLowerCase();
+      const isEps = host === "ebayimg.com" || host.endsWith(".ebayimg.com");
+      if (u.protocol === "https:" && isEps && !out.includes(raw)) out.push(raw);
+    } catch {
+      /* not a URL — skip */
+    }
+  }
+  return out.slice(0, 12);
 }
 
 export interface PublishResult {
@@ -856,10 +880,15 @@ async function findPublishedOffer(
 // Upload photos with limited concurrency, preserving order. Sequential uploads
 // were the slowest part of a publish (12 photos ≈ up to a minute on their own)
 // and pushed long batches into Vercel's function timeout.
-async function uploadPhotos(
+// Exported for /api/ebay/upload-photos, which runs this over small client-side
+// batches so the publish request itself carries URLs instead of photo bytes.
+export async function uploadPhotos(
   accessToken: string,
   images: { mediaType: string; data: string }[],
-  sku: string
+  sku: string,
+  // Photo numbering offset, so batched uploads name photos K72-O-1 … K72-O-12
+  // across batches instead of restarting at 1 in each.
+  nameOffset = 0
 ): Promise<string[]> {
   const results: (string | null)[] = new Array(images.length).fill(null);
   let cursor = 0;
@@ -870,7 +899,7 @@ async function uploadPhotos(
         accessToken,
         images[i].data,
         images[i].mediaType,
-        `${sku}-${i + 1}.jpg`
+        `${sku}-${nameOffset + i + 1}.jpg`
       );
     }
   });
@@ -937,8 +966,13 @@ export async function publishListing(
     };
   }
 
-  // 1. Upload photos → EPS URLs (parallel, order preserved).
-  const photoUrls = await uploadPhotos(accessToken, input.images.slice(0, 12), sku);
+  // 1. Photo URLs — pre-uploaded by the client in small batches (preferred),
+  // or uploaded here from base64 (legacy single-request flow).
+  const providedUrls = sanitizeEbayImageUrls(input.imageUrls);
+  const legacyImages = Array.isArray(input.images) ? input.images.slice(0, 12) : [];
+  const photoUrls = providedUrls.length
+    ? providedUrls
+    : await uploadPhotos(accessToken, legacyImages, sku);
   if (photoUrls.length === 0) {
     return { success: false, sku, error: "Could not upload any photos to eBay." };
   }
@@ -989,8 +1023,9 @@ export async function publishListing(
   } else {
     // Category-aware pass with the ORIGINAL PHOTOS + eBay's exact aspect
     // schema — recovers details (model numbers, fabric contents, necklines…)
-    // that the first, schema-blind analysis missed.
-    await fillRecommendedAspects(listing, aspects, aspectMeta, sku, input.images);
+    // that the first, schema-blind analysis missed. Photos arrive as base64
+    // (legacy flow) or as the eBay-hosted URLs (batched-upload flow).
+    await fillRecommendedAspects(listing, aspects, aspectMeta, sku, legacyImages, photoUrls);
     // Trim every aspect to a legal value count now that cardinality is known.
     enforceCardinality(aspects, aspectMeta);
   }

--- a/lib/images.ts
+++ b/lib/images.ts
@@ -24,6 +24,14 @@ export function toImageBlock(img: WireImage | undefined): ImageBlock | null {
   };
 }
 
+// Image block for an already-hosted photo (e.g. eBay Picture Services after
+// the batched upload step) — Anthropic fetches the URL itself, so the photo
+// never has to ride through our serverless functions again.
+export function urlImageBlock(url: string): ImageBlock | null {
+  if (!/^https:\/\//i.test(url)) return null;
+  return { type: "image", source: { type: "url", url } };
+}
+
 // Build "Photo N:" text + image content blocks for a set of images, matching
 // _images_to_content() in the Python script.
 export function labeledContent(

--- a/lib/uploadBatches.ts
+++ b/lib/uploadBatches.ts
@@ -1,0 +1,48 @@
+// Split a listing's photos into upload batches that stay far under Vercel's
+// 4.5 MB serverless request-body limit.
+//
+// Photos reach eBay via /api/ebay/upload-photos in these batches; the publish
+// request then carries only the returned eBay-hosted URLs, so no request in
+// the posting flow can ever hit the body limit again (the old single-request
+// flow shipped all 12 base64 photos at once and 413-failed on photo-heavy
+// items like chunky knits).
+
+export interface UploadImage {
+  mediaType: string;
+  data: string; // raw base64, no data-url prefix
+}
+
+// ~2.8 MB of base64 (~2.1 MB of image data) per request. Browser-resized
+// photos run ~200–800 KB of base64 each, so batches hold 3–4 photos and even
+// a worst-case single photo stays nowhere near the 4.5 MB platform limit.
+export const MAX_BATCH_BASE64_CHARS = 2_800_000;
+// Bound the count too, so many tiny photos don't pile into one slow request.
+export const MAX_BATCH_PHOTOS = 4;
+
+export function chunkImagesForUpload<T extends UploadImage>(
+  images: T[],
+  maxChars: number = MAX_BATCH_BASE64_CHARS,
+  maxPhotos: number = MAX_BATCH_PHOTOS
+): T[][] {
+  const batches: T[][] = [];
+  let current: T[] = [];
+  let currentChars = 0;
+
+  for (const img of images) {
+    const size = img.data.length;
+    const wouldOverflow =
+      current.length > 0 &&
+      (current.length >= maxPhotos || currentChars + size > maxChars);
+    if (wouldOverflow) {
+      batches.push(current);
+      current = [];
+      currentChars = 0;
+    }
+    // An oversize single photo still ships alone rather than being dropped —
+    // one browser-resized photo can't approach the platform limit.
+    current = [...current, img];
+    currentChars += size;
+  }
+  if (current.length) batches.push(current);
+  return batches;
+}

--- a/tests/publish-helpers.test.ts
+++ b/tests/publish-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { validListingPrice } from "@/lib/ebay/publish";
+import { sanitizeEbayImageUrls, validListingPrice } from "@/lib/ebay/publish";
 import { prioritizeAspects } from "@/lib/ebay/aspectFill";
 import type { AspectMeta } from "@/lib/ebay/taxonomy";
 
@@ -50,5 +50,39 @@ describe("prioritizeAspects", () => {
     ]);
     // Stable within a tier.
     expect(sorted.map((a) => a.name)).toEqual(["Req1", "Rec1", "Rec2", "Opt1", "Opt2"]);
+  });
+});
+
+describe("sanitizeEbayImageUrls", () => {
+  const eps = (n: number) => `https://i.ebayimg.com/00/s/MTYwMFgxMjAw/z/pic${n}.jpg`;
+
+  test("accepts https eBay Picture Services URLs, preserving order", () => {
+    const urls = [eps(1), eps(2), eps(3)];
+    expect(sanitizeEbayImageUrls(urls)).toEqual(urls);
+  });
+
+  test("rejects non-eBay hosts, plain http, and junk", () => {
+    expect(
+      sanitizeEbayImageUrls([
+        "https://evil.example.com/pic.jpg",
+        "http://i.ebayimg.com/insecure.jpg",
+        "https://notebayimg.com/pic.jpg",
+        "https://fakeebayimg.com.evil.net/pic.jpg",
+        "not a url",
+        42,
+        null,
+      ])
+    ).toEqual([]);
+  });
+
+  test("dedupes and caps at eBay's 12-photo limit", () => {
+    const urls = Array.from({ length: 15 }, (_, i) => eps(i));
+    expect(sanitizeEbayImageUrls(urls)).toHaveLength(12);
+    expect(sanitizeEbayImageUrls([eps(1), eps(1), eps(2)])).toEqual([eps(1), eps(2)]);
+  });
+
+  test("non-array input yields no URLs", () => {
+    expect(sanitizeEbayImageUrls(undefined)).toEqual([]);
+    expect(sanitizeEbayImageUrls("https://i.ebayimg.com/x.jpg")).toEqual([]);
   });
 });

--- a/tests/upload-batches.test.ts
+++ b/tests/upload-batches.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import {
+  chunkImagesForUpload,
+  MAX_BATCH_BASE64_CHARS,
+  MAX_BATCH_PHOTOS,
+} from "../lib/uploadBatches";
+
+const img = (id: string, chars: number) => ({
+  mediaType: "image/jpeg",
+  data: id.repeat(chars),
+});
+
+describe("chunkImagesForUpload", () => {
+  test("returns no batches for no images", () => {
+    expect(chunkImagesForUpload([])).toEqual([]);
+  });
+
+  test("keeps a small set in a single batch", () => {
+    const images = [img("a", 100), img("b", 100), img("c", 100)];
+    expect(chunkImagesForUpload(images)).toEqual([images]);
+  });
+
+  test("caps the number of photos per batch", () => {
+    const images = Array.from({ length: 9 }, (_, i) => img(String(i), 10));
+    const batches = chunkImagesForUpload(images);
+    expect(batches.map((b) => b.length)).toEqual([4, 4, 1]);
+  });
+
+  test("starts a new batch when the base64 budget would overflow", () => {
+    const third = Math.ceil(MAX_BATCH_BASE64_CHARS / 3);
+    // Two fit under the budget; the third would overflow it.
+    const images = [img("a", third), img("b", third), img("c", third)];
+    const batches = chunkImagesForUpload(images);
+    expect(batches.map((b) => b.length)).toEqual([2, 1]);
+  });
+
+  test("ships an oversize single photo alone instead of dropping it", () => {
+    const images = [img("a", MAX_BATCH_BASE64_CHARS + 10), img("b", 100)];
+    const batches = chunkImagesForUpload(images);
+    expect(batches.map((b) => b.length)).toEqual([1, 1]);
+    expect(batches[0][0].data.length).toBeGreaterThan(MAX_BATCH_BASE64_CHARS);
+  });
+
+  test("preserves photo order across batches", () => {
+    const images = Array.from({ length: MAX_BATCH_PHOTOS * 2 + 1 }, (_, i) =>
+      img(`${i}`, 10)
+    );
+    const flattened = chunkImagesForUpload(images).flat();
+    expect(flattened).toEqual(images);
+  });
+
+  test("honors custom limits", () => {
+    const images = [img("a", 5), img("b", 5), img("c", 5)];
+    expect(chunkImagesForUpload(images, 100, 2).map((b) => b.length)).toEqual([2, 1]);
+    expect(chunkImagesForUpload(images, 9, 4).map((b) => b.length)).toEqual([1, 1, 1]);
+  });
+});


### PR DESCRIPTION
## Problem
Posting a listing sent the listing plus up to 12 base64 photos (~4–8 MB) in **one** request to `/api/ebay/publish`. Vercel rejects bodies over 4.5 MB with a plain-text 413, which the UI surfaced as *"That was too much photo data to send at once. Try sorting fewer photos per batch"* — advice that doesn't apply to posting. Photo-heavy items (e.g. texture-dense knits that compress poorly) failed to post with no workaround.

## Fix
- **New route `/api/ebay/upload-photos`**: uploads one small batch of photos to eBay Picture Services and returns the hosted URLs. Guarded by the same access/rate-limit checks, capped at 6 photos/request.
- **Client** (`postGroup`): splits a listing's photos into size-bounded batches (~2.8 MB / max 4 photos, `lib/uploadBatches.ts`), uploads them first with transient-error retries, then publishes with just the URLs — a few-KB body that can never 413.
- **Publish pipeline**: accepts `imageUrls` (validated to `*.ebayimg.com` https hosts, deduped, capped at 12) and skips the server-side upload; legacy base64 `images` still works.
- **Aspect-fill vision pass**: reads the eBay-hosted URLs via Anthropic URL image blocks, so photo-grounded item specifics work exactly as before — no photo loss, no quality loss.
- Partial upload failures surface as post warnings instead of silently shipping a thin listing.
- The 413 message is now context-aware (sort advice only on the sort step).

## Test plan
- [x] 129 unit tests pass, incl. new suites for `chunkImagesForUpload` (size/count caps, order, oversize handling) and `sanitizeEbayImageUrls` (host allowlist, dedupe, cap)
- [x] `next build` passes; new route registered
- [x] Live route checks: 400 on missing fields, 400 on oversized batch, 401 without eBay connection; publish accepts URL-only bodies
- [ ] Post a real photo-heavy listing after deploy (needs live eBay connection)