### PR TITLE
fix: FUNCTION_INVOCATION_TIMEOUT on big sorts — time-budget the sort pipeline

### DIFF
--- a/app/api/sort/route.ts
+++ b/app/api/sort/route.ts
@@ -5,8 +5,11 @@ import { sortPhotos, SortUnavailableError } from "@/lib/sortPipeline";
 import { isAllowedModel } from "@/lib/models";
 import type { WireImage } from "@/lib/images";
 
-// Sorting makes several model calls across grouping/verify/merge stages.
-export const maxDuration = 120;
+// Sorting makes several model calls across grouping/verify/merge stages. 300s
+// (already used by the publish route) gives slow Anthropic days room to finish;
+// the pipeline's own SORT_TIME_BUDGET_MS (250s) makes it return a partial
+// result before the platform would kill the function.
+export const maxDuration = 300;
 
 const MAX_PHOTOS = 120;
 

--- a/lib/sortPipeline.ts
+++ b/lib/sortPipeline.ts
@@ -18,6 +18,18 @@ const GROUP_CONCURRENCY = 2;
 const VERIFY_CONCURRENCY = 3;
 const MERGE_CONCURRENCY = 4;
 
+// The sort route runs under a 300s Vercel maxDuration. Stop starting new work
+// with headroom to spare so a slow run returns a usable (if less polished)
+// result instead of being killed by the platform (FUNCTION_INVOCATION_TIMEOUT,
+// which loses everything).
+export const SORT_TIME_BUDGET_MS = 250_000;
+// Cap each Anthropic call — the SDK default timeout is 10 MINUTES, so one
+// stalled call could otherwise eat the whole function budget before our own
+// retry logic ever saw it.
+const PER_CALL_TIMEOUT_MS = 60_000;
+// Don't bother starting a call with less budget than this left.
+const MIN_CALL_MS = 5_000;
+
 const RETRYABLE_STATUS = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
 
 export interface SortGroup {
@@ -65,20 +77,33 @@ async function mapLimit<T, R>(
 }
 
 // Call Claude and parse JSON, retrying transient/rate-limit errors with backoff.
+// `deadline` (epoch ms) bounds the whole attempt loop: calls are skipped once
+// the budget is (nearly) spent, and each call's HTTP timeout never extends past
+// it. SDK-internal retries are disabled — this loop is the only retry layer, so
+// time spent is predictable.
 async function claudeJson<T>(
   client: Anthropic,
   model: string,
   content: Anthropic.ContentBlockParam[],
   maxTokens: number,
-  label: string
+  label: string,
+  deadline: number
 ): Promise<T | null> {
   for (let attempt = 0; attempt < 4; attempt++) {
+    const remaining = deadline - Date.now();
+    if (remaining < MIN_CALL_MS) {
+      console.warn(`[sort] ${label}: time budget exhausted — skipping call`);
+      return null;
+    }
     try {
-      const resp = await client.messages.create({
-        model,
-        max_tokens: maxTokens,
-        messages: [{ role: "user", content }],
-      });
+      const resp = await client.messages.create(
+        {
+          model,
+          max_tokens: maxTokens,
+          messages: [{ role: "user", content }],
+        },
+        { timeout: Math.min(PER_CALL_TIMEOUT_MS, remaining), maxRetries: 0 }
+      );
       return parseModelJson<T>(firstText(resp));
     } catch (e) {
       const status =
@@ -91,6 +116,10 @@ async function claudeJson<T>(
       const retryable = status === undefined || RETRYABLE_STATUS.has(status);
       if (attempt < 3 && retryable) {
         const wait = Math.min(10000, 800 * 2 ** attempt) + Math.floor(Math.random() * 400);
+        if (Date.now() + wait + MIN_CALL_MS >= deadline) {
+          console.warn(`[sort] ${label}: no budget left for retry — giving up`);
+          return null;
+        }
         console.warn(`[sort] ${label}: ${status ?? "parse/conn"} error — retry ${attempt + 1} in ${wait}ms`);
         await sleep(wait);
         continue;
@@ -108,7 +137,8 @@ async function claudeJson<T>(
 async function groupPhotos(
   client: Anthropic,
   images: WireImage[],
-  model: string
+  model: string,
+  deadline: number
 ): Promise<{ name: string; indices: number[] }[]> {
   const total = images.length;
   const batches: { offset: number; batch: WireImage[]; labelStart: number; labelEnd: number }[] = [];
@@ -129,7 +159,7 @@ async function groupPhotos(
     });
     const data = await claudeJson<{
       groups?: { folder_name?: string; photo_indices?: number[] }[];
-    }>(client, model, content, 2000, `group ${b.labelStart}-${b.labelEnd}`);
+    }>(client, model, content, 2000, `group ${b.labelStart}-${b.labelEnd}`, deadline);
 
     const out: { name: string; indices: number[] }[] = [];
     for (const g of data?.groups ?? []) {
@@ -156,11 +186,14 @@ async function groupPhotos(
 }
 
 // Step 2 — verify each multi-photo group for accidentally mixed items.
+// A verify that can't run (budget spent) keeps the group as sorted — a rougher
+// result beats a platform timeout that loses the whole sort.
 async function verifyGroups(
   client: Anthropic,
   images: WireImage[],
   groups: { name: string; indices: number[] }[],
-  model: string
+  model: string,
+  deadline: number
 ): Promise<{ groups: { name: string; indices: number[] }[]; orphans: number[] }> {
   const orphans: number[] = [];
 
@@ -173,7 +206,8 @@ async function verifyGroups(
       model,
       content,
       300,
-      `verify ${group.name}`
+      `verify ${group.name}`,
+      deadline
     );
 
     if (!result || result.valid !== false) return group;
@@ -192,11 +226,13 @@ async function verifyGroups(
 }
 
 // Step 3 — merge adjacent groups that are really one item split in two.
+// A pair that can't be checked (budget spent) simply stays unmerged.
 async function mergeSplitGroups(
   client: Anthropic,
   images: WireImage[],
   groups: { name: string; indices: number[] }[],
-  model: string
+  model: string,
+  deadline: number
 ): Promise<{ name: string; indices: number[] }[]> {
   if (groups.length < 2) return groups;
 
@@ -219,7 +255,8 @@ async function mergeSplitGroups(
       model,
       content,
       100,
-      `merge ${i}`
+      `merge ${i}`,
+      deadline
     );
     return result?.merge === true;
   });
@@ -278,7 +315,9 @@ export async function checkMergePair(
     model ?? CHECK_MODEL,
     content,
     100,
-    "merge chunk-boundary"
+    "merge chunk-boundary",
+    // The merge-check route runs under a 30s maxDuration — budget within it.
+    Date.now() + 25_000
   );
   return result?.merge === true;
 }
@@ -286,12 +325,14 @@ export async function checkMergePair(
 export async function sortPhotos(
   client: Anthropic,
   images: WireImage[],
-  model?: string
+  model?: string,
+  budgetMs: number = SORT_TIME_BUDGET_MS
 ): Promise<SortResult> {
   const m = model ?? GROUP_MODEL;
-  const grouped = await groupPhotos(client, images, m);
+  const deadline = Date.now() + budgetMs;
+  const grouped = await groupPhotos(client, images, m, deadline);
   if (grouped.length === 0) return { groups: [], orphanIndices: [] };
-  const verified = await verifyGroups(client, images, grouped, m);
-  const merged = await mergeSplitGroups(client, images, verified.groups, m);
+  const verified = await verifyGroups(client, images, grouped, m, deadline);
+  const merged = await mergeSplitGroups(client, images, verified.groups, m, deadline);
   return { groups: uniqueNames(merged), orphanIndices: verified.orphans };
 }

--- a/tests/sortPipeline.test.ts
+++ b/tests/sortPipeline.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import type Anthropic from "@anthropic-ai/sdk";
+import { sortPhotos, SortUnavailableError } from "@/lib/sortPipeline";
+import type { WireImage } from "@/lib/images";
+
+// A tiny valid-looking base64 payload; content is never decoded in the pipeline.
+const IMG: WireImage = { mediaType: "image/jpeg", data: "aGVsbG8=" };
+
+function groupResponse(json: unknown): Anthropic.Message {
+  return {
+    content: [{ type: "text", text: JSON.stringify(json) }],
+  } as unknown as Anthropic.Message;
+}
+
+function mockClient(create: ReturnType<typeof vi.fn>): Anthropic {
+  return { messages: { create } } as unknown as Anthropic;
+}
+
+describe("sortPhotos time budgeting", () => {
+  it("caps each Anthropic call's timeout and disables SDK-internal retries", async () => {
+    const create = vi.fn().mockResolvedValue(
+      groupResponse({ groups: [{ folder_name: "shirt", photo_indices: [1, 2] }] })
+    );
+
+    await sortPhotos(mockClient(create), [IMG, IMG]);
+
+    expect(create).toHaveBeenCalled();
+    for (const call of create.mock.calls) {
+      const options = call[1] as { timeout?: number; maxRetries?: number };
+      expect(options.maxRetries).toBe(0);
+      expect(options.timeout).toBeDefined();
+      expect(options.timeout!).toBeLessThanOrEqual(60_000);
+      expect(options.timeout!).toBeGreaterThan(0);
+    }
+  });
+
+  it("skips calls entirely once the budget is exhausted", async () => {
+    const create = vi.fn().mockResolvedValue(
+      groupResponse({ groups: [{ folder_name: "shirt", photo_indices: [1] }] })
+    );
+
+    // Zero budget: every grouping batch is skipped → total-failure error.
+    await expect(sortPhotos(mockClient(create), [IMG, IMG], undefined, 0)).rejects.toThrow(
+      SortUnavailableError
+    );
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns grouped results even when verify/merge budget runs out mid-run", async () => {
+    let calls = 0;
+    const create = vi.fn().mockImplementation(async () => {
+      calls++;
+      // First call: grouping succeeds. Later calls (verify/merge) stall past
+      // their per-call timeout budget — simulate by rejecting like a timeout.
+      if (calls === 1) {
+        return groupResponse({
+          groups: [
+            { folder_name: "shirt", photo_indices: [1, 2] },
+            { folder_name: "mug", photo_indices: [3] },
+          ],
+        });
+      }
+      const err = new Error("Request timed out.") as Error & { status?: number };
+      throw err; // status undefined → retryable, but budget-bounded
+    });
+
+    // Small budget: grouping fits, but verify/merge retries are cut off by the
+    // deadline instead of looping through the full backoff schedule.
+    const result = await sortPhotos(mockClient(create), [IMG, IMG, IMG], undefined, 6_000);
+
+    expect(result.groups.map((g) => g.name)).toEqual(["shirt", "mug"]);
+    expect(result.groups[0].photoIndices).toEqual([0, 1]);
+    expect(result.orphanIndices).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem
Sorting 153 photos died with Vercel `FUNCTION_INVOCATION_TIMEOUT`. Nothing in the app changed — the sort route has always run right up against its 120s `maxDuration` on a 100-photo chunk, and two things made it fragile on a slow-API day:

1. **No Anthropic client timeout.** The SDK default is **10 minutes** per call, plus 2 silent SDK-internal retries. One stalled/slow call could eat the entire function budget before the pipeline's own retry loop ever saw it.
2. **No deadline awareness.** The pipeline's 4-attempt retry loop with backoff happily kept working past the point where the platform would kill the function — losing the whole sort.

## Fix
- `/api/sort` `maxDuration` 120 → **300** (the publish route already runs at 300 on this deployment).
- Every pipeline call now gets a **60s per-call timeout** and `maxRetries: 0` (the pipeline's own loop is the single retry layer, so time spent is predictable).
- A **250s soft budget** (`SORT_TIME_BUDGET_MS`) is threaded through group → verify → merge: calls and retries stop when the budget is spent. Verify/merge that can't run keep groups as sorted — a slightly rougher sort instead of a platform kill.
- `/api/merge-check` budgets 25s under its 30s cap.

## Tests
- `tests/sortPipeline.test.ts` (new): per-call timeout/maxRetries wiring, zero-budget skip → `SortUnavailableError`, and partial results when verify/merge budget runs out mid-run.
- Full suite: **132 passed**. `npm run build` clean.

## Ship
Merge → `git pull` in the local folder → `./deploy.sh` (no auto-deploy).