### PR TITLE
fix: FUNCTION_INVOCATION_TIMEOUT when writing listings — time-budget /api/analyze

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -13,12 +13,25 @@ import { applyPriceMarkup, priceMarkupPercent } from "@/lib/pricing";
 import { resolveModel } from "@/lib/models";
 import type { AnalyzeRequestBody, ListingResult } from "@/lib/types";
 
-// Analysis can take 20-40s for a multi-photo item. Give it room.
-export const maxDuration = 60;
+// Analysis takes 20-40s for a multi-photo item on a good day — and far longer
+// when the API is slow. Run under the platform's 300s cap with our own budget
+// (below) so a slow run fails with an error we control and a working Retry,
+// not a platform kill (FUNCTION_INVOCATION_TIMEOUT).
+export const maxDuration = 300;
 
 const ANALYSIS_MODEL = "claude-opus-4-8";
 const ROUTER_MODEL = "claude-sonnet-4-6";
 const MAX_IMAGES = 12;
+
+// Stop starting work once the budget is spent — headroom under maxDuration.
+const ANALYZE_TIME_BUDGET_MS = 250_000;
+// Per-call caps: the SDK's default timeout is 10 MINUTES, so without these one
+// stalled call would eat the whole function budget. SDK-internal retries stay
+// off — the loops below are the single retry layer.
+const ROUTER_TIMEOUT_MS = 20_000;
+const ANALYSIS_CALL_TIMEOUT_MS = 120_000;
+// Don't bother starting a call with less budget than this left.
+const MIN_CALL_MS = 5_000;
 
 function toImageBlocks(images: AnalyzeRequestBody["images"]): ImageBlock[] {
   const blocks: ImageBlock[] = [];
@@ -30,29 +43,38 @@ function toImageBlocks(images: AnalyzeRequestBody["images"]): ImageBlock[] {
 }
 
 // Mirrors route_item_profile(): honor a forced profile, else ask the model.
+// Falls back to hard_goods when the router can't run (error or budget spent) —
+// same fallback the catch below has always used.
 async function routeProfile(
   client: Anthropic,
   imageBlocks: ImageBlock[],
   requested: string,
-  routerModel: string
+  routerModel: string,
+  deadline: number
 ): Promise<string> {
   const forced = normalizeItemProfile(requested);
   if (forced !== "auto") return forced;
 
+  const remaining = deadline - Date.now();
+  if (remaining < MIN_CALL_MS) return "hard_goods";
+
   try {
-    const resp = await client.messages.create({
-      model: routerModel,
-      max_tokens: 300,
-      messages: [
-        {
-          role: "user",
-          content: [
-            ...imageBlocks,
-            { type: "text", text: PROFILE_ROUTER_PROMPT },
-          ],
-        },
-      ],
-    });
+    const resp = await client.messages.create(
+      {
+        model: routerModel,
+        max_tokens: 300,
+        messages: [
+          {
+            role: "user",
+            content: [
+              ...imageBlocks,
+              { type: "text", text: PROFILE_ROUTER_PROMPT },
+            ],
+          },
+        ],
+      },
+      { timeout: Math.min(ROUTER_TIMEOUT_MS, remaining), maxRetries: 0 }
+    );
     const text = firstText(resp);
     const data = parseModelJson<{ profile?: string }>(text);
     const routed = normalizeItemProfile(data?.profile ?? "auto");
@@ -116,38 +138,48 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const profile = await routeProfile(client, imageBlocks, body.profile, routerModel);
+    const deadline = Date.now() + ANALYZE_TIME_BUDGET_MS;
+    const profile = await routeProfile(client, imageBlocks, body.profile, routerModel, deadline);
     const systemPrompt = buildProfiledAnalysisPrompt(profile);
 
-    // Retry up to 3 times, mirroring the Python analyze_photos() loop.
+    // Retry up to 3 times, mirroring the Python analyze_photos() loop — but
+    // never start an attempt the time budget can't cover.
     let lastErr: unknown = null;
     for (let attempt = 0; attempt < 3; attempt++) {
+      const remaining = deadline - Date.now();
+      if (remaining < MIN_CALL_MS) {
+        lastErr = lastErr ?? new Error("Analysis ran out of time — the API is slow right now.");
+        break;
+      }
       try {
-        const resp = await client.messages.create({
-          model: analysisModel,
-          max_tokens: 3000,
-          // System prompt is large and identical across requests for the same
-          // profile — cache it to cut cost and latency.
-          system: [
-            {
-              type: "text",
-              text: systemPrompt,
-              cache_control: { type: "ephemeral" },
-            },
-          ],
-          messages: [
-            {
-              role: "user",
-              content: [
-                ...imageBlocks,
-                {
-                  type: "text",
-                  text: "Analyze these photos and return the listing JSON now.",
-                },
-              ],
-            },
-          ],
-        });
+        const resp = await client.messages.create(
+          {
+            model: analysisModel,
+            max_tokens: 3000,
+            // System prompt is large and identical across requests for the same
+            // profile — cache it to cut cost and latency.
+            system: [
+              {
+                type: "text",
+                text: systemPrompt,
+                cache_control: { type: "ephemeral" },
+              },
+            ],
+            messages: [
+              {
+                role: "user",
+                content: [
+                  ...imageBlocks,
+                  {
+                    type: "text",
+                    text: "Analyze these photos and return the listing JSON now.",
+                  },
+                ],
+              },
+            ],
+          },
+          { timeout: Math.min(ANALYSIS_CALL_TIMEOUT_MS, remaining), maxRetries: 0 }
+        );
         const listing = parseModelJson<ListingResult>(firstText(resp));
         listing.item_profile = profile;
         // Deterministic title cleanup happens HERE, before the seller reviews —


### PR DESCRIPTION
## Problem
After PR #42 fixed sorting, the same platform timeout surfaced on **Write listings**: `/api/analyze` runs the app's heaviest calls — Opus 4.8 with up to 12 ~1024px photos, up to 3 attempts, plus a Sonnet profile-router call — under a **60s** `maxDuration`, with **no Anthropic client timeout** (SDK default is 10 minutes, plus 2 silent SDK-internal retries). On a slow-API day one attempt alone exceeds 60s, and a stalled call eats the whole budget.

## Fix (mirrors #42)
- `maxDuration` 60 → **300**.
- **250s soft budget** per request: attempts that can't fit are skipped and the route returns its own error (the card's Retry button keeps working).
- Profile router: **20s** per-call timeout; falls back to `hard_goods` when out of budget (same fallback it always had on error).
- Analysis call: **120s** per-call timeout, SDK-internal retries off — the route's existing retry loop is the single retry layer, so time spent is predictable.

## Tests
Full suite: **132 passed**. `npm run build` clean. (Route handlers have no unit-test harness in this repo; the timeout wiring matches the pattern tested in `tests/sortPipeline.test.ts`.)

## Ship
Merge → `git pull` in the local folder → `./deploy.sh` (no auto-deploy).