### PR TITLE
fix: eBay 25002 numeric-aspect rejections (Fabric Weight = "Heavyweight") — sanitize + recover

### DIFF
--- a/lib/ebay/aspects.ts
+++ b/lib/ebay/aspects.ts
@@ -92,6 +92,38 @@ export function enforceCardinality(
   }
 }
 
+// eBay hard-validates NUMBER-typed aspects at publish time ("Fabric weight
+// must be greater than 0. Enter up to 1 number after the decimal.") — a prose
+// value like "Heavyweight" fails the whole listing with 25002. Keep only a
+// positive numeric token pulled from each value ("6.1 oz" → "6.1", int32
+// aspects rounded to whole numbers) and drop the aspect entirely when none of
+// its values contain one. Returns the names of dropped aspects for logging.
+export function sanitizeNumericAspects(
+  aspects: Record<string, string[]>,
+  meta: AspectMeta[]
+): string[] {
+  const dropped: string[] = [];
+  const byName = new Map(meta.map((a) => [a.name.toLowerCase(), a]));
+  for (const key of Object.keys(aspects)) {
+    const a = byName.get(key.toLowerCase());
+    if (!a || a.dataType !== "NUMBER") continue;
+    const kept: string[] = [];
+    for (const v of aspects[key] || []) {
+      const m = String(v).match(/-?\d+(?:\.\d+)?/);
+      if (!m) continue;
+      const num = a.format === "int32" ? String(Math.round(Number(m[0]))) : m[0];
+      if (Number(num) > 0 && !kept.includes(num)) kept.push(num);
+    }
+    if (kept.length) {
+      aspects[key] = kept;
+    } else {
+      delete aspects[key];
+      dropped.push(key);
+    }
+  }
+  return dropped;
+}
+
 // Match a value against eBay's allowed list, case-insensitively and tolerating
 // singular/plural (so "Unisex Adult" resolves to the valid "Unisex Adults").
 // Returns the canonical allowed value, or null if there's no match.

--- a/lib/ebay/publish.ts
+++ b/lib/ebay/publish.ts
@@ -23,6 +23,7 @@ import {
   matchAllowed,
   canonicalizeAspectKeys,
   enforceCardinality,
+  sanitizeNumericAspects,
 } from "./aspects";
 import { fillRecommendedAspects } from "./aspectFill";
 import { extractProductIdentifiers, hasCatalogIdentifier, realBrand } from "./identifiers";
@@ -624,6 +625,60 @@ function addMissingAspects(
   return added;
 }
 
+// eBay rejected the VALUE of a specific aspect we sent (25002 "A user error
+// has occurred. Fabric weight must be greater than 0. Enter up to 1 number
+// after the decimal."). Find which sent aspect the error message names so the
+// recovery can drop it and retry — the aspect name must appear as a whole
+// word/phrase alongside validation-ish language. "Missing" errors are
+// deliberately excluded (extractMissingAspects owns those), and word
+// boundaries keep "Brand" from matching eBay's "<BrandMPN>" tag errors.
+const ASPECT_VALUE_ERROR_RE =
+  /must be|invalid|format|greater than|less than|number|decimal|numeric/i;
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function findInvalidValueAspects(
+  r: EbayResp,
+  aspects: Record<string, string[]>
+): string[] {
+  const hits: string[] = [];
+  for (const err of r.json?.errors || []) {
+    for (const piece of [err.message, err.longMessage]) {
+      const msg = String(piece || "");
+      if (!msg || !ASPECT_VALUE_ERROR_RE.test(msg) || /is missing/i.test(msg)) continue;
+      for (const name of Object.keys(aspects)) {
+        if (name.length < 3) continue;
+        const re = new RegExp(`\\b${escapeRegExp(name)}\\b`, "i");
+        if (re.test(msg) && !hits.includes(name)) hits.push(name);
+      }
+    }
+  }
+  return hits;
+}
+
+// Recovery: drop the named aspects and retry once. Losing one searchable
+// specific beats failing the whole publish; if the aspect was REQUIRED, eBay's
+// next error says exactly which specific is missing, which the seller can act
+// on directly.
+export function applyInvalidAspectFallback(
+  inventoryItem: { product: { aspects?: Record<string, string[]> } },
+  aspects: Record<string, string[]>,
+  names: string[],
+  sku: string
+): void {
+  for (const n of names) {
+    console.warn(
+      `[ebay/publish] sku=${sku} eBay rejected the value of aspect "${n}" (${JSON.stringify(
+        aspects[n] ?? []
+      )}) — retrying without it`
+    );
+    delete aspects[n];
+  }
+  inventoryItem.product.aspects = aspects;
+}
+
 // eBay's Brand/MPN pair validation (25002, tag <BrandMPN>): fires when an MPN
 // arrives without a brand, when the pair doesn't match a catalog product, or
 // when a category requires the Brand/MPN aspects and one is absent.
@@ -1028,6 +1083,15 @@ export async function publishListing(
     await fillRecommendedAspects(listing, aspects, aspectMeta, sku, legacyImages, photoUrls);
     // Trim every aspect to a legal value count now that cardinality is known.
     enforceCardinality(aspects, aspectMeta);
+    // NUMBER-typed aspects must carry a bare positive number or eBay rejects
+    // the publish (25002 "Fabric weight must be greater than 0") — run LAST so
+    // model-filled and reconciled values are covered too.
+    const droppedNumeric = sanitizeNumericAspects(aspects, aspectMeta);
+    if (droppedNumeric.length) {
+      console.warn(
+        `[ebay/publish] sku=${sku} dropped non-numeric value(s) for numeric aspect(s): ${droppedNumeric.join(", ")}`
+      );
+    }
   }
   const condCandidates = conditionCandidates(listing.condition, acceptedConds, catKey);
   const condition = condCandidates[0] || "USED_EXCELLENT";
@@ -1088,6 +1152,15 @@ export async function publishListing(
     if (![200, 201, 204].includes(r.status) && isShippingPackageError(r)) {
       applyShippingPackageFallback(inventoryItem, sku);
       r = await putInventory();
+    }
+    // Recovery: an aspect VALUE eBay's validators rejected (25002 "Fabric
+    // weight must be greater than 0") → drop the named aspect(s), retry once.
+    if (![200, 201, 204].includes(r.status)) {
+      const badAspects = findInvalidValueAspects(r, aspects);
+      if (badAspects.length) {
+        applyInvalidAspectFallback(inventoryItem, aspects, badAspects, sku);
+        r = await putInventory();
+      }
     }
     // Recovery: condition invalid for this category (25021/25059) → step down
     // to a grade the category accepts.
@@ -1319,6 +1392,18 @@ async function publishOfferWithRecovery(
   // Brand/MPN, eBay validates this at publish time.
   if (isShippingPackageError(r)) {
     applyShippingPackageFallback(ctx.inventoryItem, sku);
+    await putInventory();
+    r = await doPublish();
+    if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "", warnings };
+    eids = errorIds(r);
+  }
+
+  // Recovery: an aspect VALUE eBay's validators rejected (25002 "Fabric weight
+  // must be greater than 0") — like Brand/MPN, this fires at publish time even
+  // when the inventory PUT succeeded. Drop the named aspect(s) and retry once.
+  const badAspects = findInvalidValueAspects(r, ctx.aspects);
+  if (badAspects.length) {
+    applyInvalidAspectFallback(ctx.inventoryItem, ctx.aspects, badAspects, sku);
     await putInventory();
     r = await doPublish();
     if (r.ok) return { success: true, sku, offerId, listingId: r.json?.listingId || "", warnings };

--- a/lib/ebay/taxonomy.ts
+++ b/lib/ebay/taxonomy.ts
@@ -35,6 +35,11 @@ export interface AspectMeta {
   // ("Cotton/Polyester") to its first value loses searchable data.
   cardinality: AspectCardinality;
   maxLength?: number;
+  // eBay validates value FORMAT at publish time for typed aspects — a prose
+  // value in a NUMBER aspect ("Fabric Weight" = "Heavyweight") hard-fails the
+  // publish with 25002 ("Fabric weight must be greater than 0").
+  dataType?: string; // e.g. "STRING" | "NUMBER" | "DATE"
+  format?: string; // e.g. "int32" | "double"
   values: string[]; // eBay's allowed/suggested values (full list for SELECTION_ONLY)
 }
 
@@ -148,6 +153,8 @@ export async function categoryAspects(categoryId: string): Promise<AspectMeta[]>
         cardinality:
           con?.itemToAspectCardinality === "MULTI" ? "MULTI" : "SINGLE",
         maxLength: Number.isFinite(maxLen) && maxLen > 0 ? maxLen : undefined,
+        dataType: con?.aspectDataType ? String(con.aspectDataType) : undefined,
+        format: con?.aspectFormat ? String(con.aspectFormat) : undefined,
         values: (a?.aspectValues ?? [])
           .map((v: any) => String(v?.localizedValue ?? "").trim())
           .filter(Boolean),

--- a/tests/numeric-aspects.test.ts
+++ b/tests/numeric-aspects.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "vitest";
+import { sanitizeNumericAspects } from "@/lib/ebay/aspects";
+import { findInvalidValueAspects } from "@/lib/ebay/publish";
+import type { AspectMeta } from "@/lib/ebay/taxonomy";
+
+const numberMeta = (name: string, format?: string): AspectMeta => ({
+  name,
+  required: false,
+  usage: "RECOMMENDED",
+  mode: "FREE_TEXT",
+  cardinality: "SINGLE",
+  dataType: "NUMBER",
+  format,
+  values: [],
+});
+
+const stringMeta = (name: string): AspectMeta => ({
+  name,
+  required: false,
+  usage: "RECOMMENDED",
+  mode: "FREE_TEXT",
+  cardinality: "SINGLE",
+  values: [],
+});
+
+describe("sanitizeNumericAspects", () => {
+  test("drops prose values in NUMBER aspects — the Fabric Weight failure", () => {
+    const aspects: Record<string, string[]> = { "Fabric Weight": ["Heavyweight"] };
+    const dropped = sanitizeNumericAspects(aspects, [numberMeta("Fabric Weight", "double")]);
+    expect(aspects["Fabric Weight"]).toBeUndefined();
+    expect(dropped).toEqual(["Fabric Weight"]);
+  });
+
+  test("extracts the numeric token from a value with units", () => {
+    const aspects: Record<string, string[]> = { "Fabric Weight": ["6.1 oz heavyweight"] };
+    sanitizeNumericAspects(aspects, [numberMeta("Fabric Weight", "double")]);
+    expect(aspects["Fabric Weight"]).toEqual(["6.1"]);
+  });
+
+  test("rounds int32 aspects to whole numbers", () => {
+    const aspects: Record<string, string[]> = { "Number of Pieces": ["3.7 pieces"] };
+    sanitizeNumericAspects(aspects, [numberMeta("Number of Pieces", "int32")]);
+    expect(aspects["Number of Pieces"]).toEqual(["4"]);
+  });
+
+  test("drops zero and negative values — eBay requires greater than 0", () => {
+    const aspects: Record<string, string[]> = { "Fabric Weight": ["0", "-2"] };
+    const dropped = sanitizeNumericAspects(aspects, [numberMeta("Fabric Weight", "double")]);
+    expect(dropped).toEqual(["Fabric Weight"]);
+  });
+
+  test("leaves STRING aspects and unknown aspects untouched", () => {
+    const aspects: Record<string, string[]> = {
+      Material: ["Heavyweight Cotton"],
+      Theme: ["Vintage 90s"],
+    };
+    const dropped = sanitizeNumericAspects(aspects, [stringMeta("Material")]);
+    expect(aspects.Material).toEqual(["Heavyweight Cotton"]);
+    expect(aspects.Theme).toEqual(["Vintage 90s"]);
+    expect(dropped).toEqual([]);
+  });
+});
+
+describe("findInvalidValueAspects", () => {
+  const resp = (message: string) => ({
+    ok: false,
+    status: 400,
+    text: message,
+    json: { errors: [{ errorId: 25002, message }] },
+  });
+
+  test("names the aspect from the real Fabric Weight publish error", () => {
+    const aspects = { "Fabric Weight": ["Heavyweight"], Brand: ["Pro Club"] };
+    const found = findInvalidValueAspects(
+      resp(
+        "A user error has occurred. Fabric weight must be greater than 0. Enter up to 1 number after the decimal."
+      ),
+      aspects
+    );
+    expect(found).toEqual(["Fabric Weight"]);
+  });
+
+  test("does not fire on BrandMPN tag errors — Brand needs a word boundary", () => {
+    const aspects = { Brand: ["Pro Club"], MPN: ["Does Not Apply"] };
+    const found = findInvalidValueAspects(
+      resp("Input data for tag <BrandMPN> is invalid or missing."),
+      aspects
+    );
+    expect(found).toEqual([]);
+  });
+
+  test("does not fire on missing-specific errors — those belong to extractMissingAspects", () => {
+    const aspects = { Size: ["L"], Type: ["T-Shirt"] };
+    const found = findInvalidValueAspects(
+      resp("The item specific Size is missing and must be added."),
+      aspects
+    );
+    expect(found).toEqual([]);
+  });
+
+  test("returns nothing when no sent aspect is named", () => {
+    const aspects = { "Fabric Weight": ["6.1"] };
+    const found = findInvalidValueAspects(
+      resp("The listing price is invalid for this format."),
+      aspects
+    );
+    expect(found).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem
Publishing a Pro Club heavyweight tee failed with **eBay error 25002: "Fabric weight must be greater than 0. Enter up to 1 number after the decimal."** The models wrote the prose value `Heavyweight` into the **Fabric Weight** item specific; eBay validates NUMBER-typed aspects at publish time and rejects the whole listing. Same class as the BrandMPN (#34) and ShippingPackage (#35) publish-time validations.

## Fix (two layers, per the established pattern)
**Prevent** — `AspectMeta` now captures `aspectDataType`/`aspectFormat` from the Taxonomy API (previously discarded), and a new `sanitizeNumericAspects()` pass runs after model aspect-fill: NUMBER aspects keep only a positive numeric token per value (`"6.1 oz"` → `"6.1"`, int32 rounded to whole numbers) and are dropped entirely when there's none (`"Heavyweight"` → dropped, logged).

**Recover** — generic fallback wired into **both** the inventory-create and publish recovery chains: `findInvalidValueAspects()` finds which sent aspect the eBay error message names (word-boundary match plus validation-ish phrasing; `is missing` errors excluded — `extractMissingAspects` owns those; boundaries keep `Brand` from matching `<BrandMPN>` errors), then `applyInvalidAspectFallback()` drops it and retries once. Losing one searchable specific beats failing the publish.

## Tests
9 new in `tests/numeric-aspects.test.ts` — the exact Fabric Weight message, unit extraction, int32 rounding, >0 enforcement, BrandMPN/missing-specific non-matches. Full suite **141 passed**, build clean.

## Ship
Merge → `git pull` → `./deploy.sh`.